### PR TITLE
Allow dashboard. prefix on currentPath

### DIFF
--- a/app/components/activating-item/component.js
+++ b/app/components/activating-item/component.js
@@ -9,6 +9,10 @@ export default Ember.Component.extend({
   currentWhen: null,
 
   active: Ember.computed('routingService.currentPath', 'currentWhen', function() {
-    return this.get('routingService.currentPath').indexOf(this.get('currentWhen')) === 0;
+    let currentPath = this.get('routingService.currentPath');
+    let currentWhen = this.get('currentWhen');
+    let offset = currentPath.indexOf(currentWhen);
+    // with our without dashboard prefix
+    return offset === 0 || (offset === 10 && currentPath.indexOf('dashboard') === 0);
   })
 });

--- a/tests/unit/components/activating-item/component-test.js
+++ b/tests/unit/components/activating-item/component-test.js
@@ -9,11 +9,41 @@ moduleForComponent('activating-item', {
   // needs: ['component:foo', 'helper:bar']
 });
 
-test('it renders', function(assert) {
+test('it is active when matching', function(assert) {
   assert.expect(5);
 
   let mockRoutingService = {
     currentPath: 'abc'
+  };
+
+  // creates the component instance
+  var component = this.subject({
+    routingService: mockRoutingService
+  });
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+
+  assert.ok(!component.get('active'), 'not active by default');
+
+  Ember.run(component, 'set', 'currentWhen', 'abc');
+
+  assert.ok(component.get('active'),
+            'active when currentWhen path matches app path');
+
+  Ember.run(component, 'set', 'currentWhen', 'ab');
+
+  assert.ok(component.get('active'),
+            'active when app path is subset of currentWhen path');
+});
+
+test('it is active when matching with dashboard prefix', function(assert) {
+  assert.expect(5);
+
+  let mockRoutingService = {
+    currentPath: 'dashboard.abc'
   };
 
   // creates the component instance


### PR DESCRIPTION
Current path may be prefixed with `dashboard.` Rather than change the usage, this commit makes the activating item component safe for that case.
