### PR TITLE
Cookie persisted auth

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,17 +3,25 @@ import DS from "ember-data";
 import Ember from "ember";
 import config from "../config/environment";
 
-export var auth = {};
+let accessToken;
+
+export function setAccessToken(token) {
+  accessToken = token;
+}
+
+export function getAccessToken() {
+  return accessToken;
+}
 
 export default HalAdapter.extend({
   host: config.apiBaseUri,
 
   headers: Ember.computed(function(){
-    if (!auth.token) {
+    if (!getAccessToken()) {
       return {};
     }
     return {
-      'Authorization': 'Bearer ' + auth.token
+      'Authorization': 'Bearer ' + getAccessToken()
     };
   }).volatile(),
 

--- a/app/aptible/torii-adapter.js
+++ b/app/aptible/torii-adapter.js
@@ -1,16 +1,14 @@
 import Ember from "ember";
-import storage from '../utils/storage';
 import config from "../config/environment";
-import JWT from '../utils/jwt';
 import ajax from "../utils/ajax";
-import { auth } from '../adapters/application';
+import { getAccessToken, setAccessToken } from '../adapters/application';
 
 function clearSession(){
-  delete auth.token;
+  setAccessToken(null);
 }
 
 function persistSession(accessToken){
-  auth.token = accessToken;
+  setAccessToken(accessToken);
 }
 
 function pushTokenToStore(tokenPayload, store) {
@@ -73,7 +71,7 @@ export default Ember.Object.extend({
     return ajax(config.authBaseUri+`/tokens/${token.get('id')}`, {
       type: 'DELETE',
       headers: {
-        'Authorization': 'Bearer ' + auth.token
+        'Authorization': 'Bearer ' + getAccessToken()
       },
       xhrFields: { withCredentials: true }
     }).then(() => {

--- a/app/aptible/torii-provider.js
+++ b/app/aptible/torii-provider.js
@@ -3,7 +3,21 @@ import ajax from "../utils/ajax";
 import config from "../config/environment";
 
 export default BaseProvider.extend({
-  open: function(credentials){
+  fetch() {
+    return ajax(config.authBaseUri+'/current_token', {
+      type: 'GET'
+    }).catch(function(jqXHR){
+      if (jqXHR.responseJSON) {
+        throw new Error(jqXHR.responseJSON.message);
+      } else if (jqXHR.responseText) {
+        throw new Error(jqXHR.responseText);
+      } else {
+        throw new Error("Unknown error from the server.");
+      }
+    });
+  },
+
+  open(credentials) {
     return ajax(config.authBaseUri+'/tokens', {
       type: 'POST',
       data: credentials,

--- a/app/aptible/torii-provider.js
+++ b/app/aptible/torii-provider.js
@@ -3,20 +3,6 @@ import ajax from "../utils/ajax";
 import config from "../config/environment";
 
 export default BaseProvider.extend({
-  fetch() {
-    return ajax(config.authBaseUri+'/current_token', {
-      type: 'GET'
-    }).catch(function(jqXHR){
-      if (jqXHR.responseJSON) {
-        throw new Error(jqXHR.responseJSON.message);
-      } else if (jqXHR.responseText) {
-        throw new Error(jqXHR.responseText);
-      } else {
-        throw new Error("Unknown error from the server.");
-      }
-    });
-  },
-
   open(credentials) {
     return ajax(config.authBaseUri+'/tokens', {
       type: 'POST',

--- a/app/mixins/routes/authenticated.js
+++ b/app/mixins/routes/authenticated.js
@@ -12,7 +12,7 @@ export default Ember.Mixin.create({
   requireAuthentication: true, // default to requiring authentication
   unauthenticatedRedirect: 'login',
 
-  beforeModel: function(transition){
+  beforeModel(transition) {
     if (this.get('requireAuthentication')) {
       return this._requireAuthentication(transition);
     } else {
@@ -21,23 +21,27 @@ export default Ember.Mixin.create({
   },
 
   // redirect if the user is not signed in
-  _requireAuthentication: function(transition){
+  _requireAuthentication(transition) {
     var route = this;
-    if (!this.session.get('isAuthenticated')) {
+    var isAuthenticated = this.get('session.isAuthenticated');
+    if (isAuthenticated === undefined) {
       this.session.attemptedTransition = transition;
       return this.session.fetch('aptible').then(function(){
         return loadUserRoles(route);
       }).catch( () => {
         route.transitionTo(Ember.get(this, 'unauthenticatedRedirect'));
       });
-    } else {
+    } else if (isAuthenticated) {
       return loadUserRoles(route);
+    } else {
+      route.transitionTo(Ember.get(this, 'unauthenticatedRedirect'));
     }
   },
 
   // check if the user is signed in, but do nothing if they are not
-  _checkLogin: function(){
-    if (!this.session.get('isAuthenticated')) {
+  _checkLogin() {
+    var isAuthenticated = this.get('session.isAuthenticated');
+    if (isAuthenticated === undefined) {
       return this.session.fetch('aptible').catch(function(){
         // no-op; it's ok if we are not logged in
       });

--- a/app/mixins/routes/disallow-authenticated.js
+++ b/app/mixins/routes/disallow-authenticated.js
@@ -5,11 +5,15 @@ import Ember from "ember";
 export default Ember.Mixin.create({
   requireAuthentication: false,
   beforeModel: function(){
+
     return new Ember.RSVP.Promise((resolve, reject) => {
-      if (this.session.get('isAuthenticated')) {
+      var isAuthenticated = this.get('session.isAuthenticated');
+      if (isAuthenticated) {
         reject();
+      } else if (isAuthenticated === undefined) {
+        return this.session.fetch('aptible').then(reject, resolve);
       } else {
-        this.session.fetch('aptible').then(reject, resolve);
+        resolve();
       }
     }).catch(() => {
       this.transitionTo('index');

--- a/tests/unit/torii-adapters/aptible-test.js
+++ b/tests/unit/torii-adapters/aptible-test.js
@@ -39,19 +39,34 @@ moduleFor('torii-adapter:aptible', 'Torii Adapter: Aptible', {
   }
 });
 
-test('adapter stores the auth token in storage', function(){
+test('#close destroys token, storage', function(){
+  var adapter = this.subject();
+
+  var removedKey;
+  storage.remove = function(key){
+    removedKey = key;
+  };
+  auth.token = 'some-token';
+
+  Ember.run(function(){
+    adapter.close().then(function(){
+      ok(true, 'session is opened with an auth_token');
+      equal(removedKey, config.authTokenKey, 'removes token value');
+      ok(!auth.token, 'unsets token on auth');
+    }, function(e){
+      ok(false, "Unexpected error: "+e);
+    });
+  });
+});
+
+
+test('#open stores payload, set currentUser', function(){
   var adapter = this.subject();
   var token = 'some-token';
   var tokenId = 'some-token-id';
   var userId = 'some-user-id';
   var userUrl = '/some-user-url';
   var userEmail = 'some@email.com';
-
-  var wroteKey, wroteVal;
-  storage.write = function(key, val){
-    wroteKey = key;
-    wroteVal = val;
-  };
 
   stubRequest('get', userUrl, function(){
     return this.success({
@@ -74,8 +89,6 @@ test('adapter stores the auth token in storage', function(){
   Ember.run(function(){
     adapter.open(optionsFromProvider).then(function(resultForSession){
       ok(true, 'session is opened with an auth_token');
-      equal(wroteKey, config.authTokenKey, 'writes to config.authTokenKey');
-      equal(wroteVal, token, 'writes token value');
       equal(auth.token, token, 'sets token on auth');
 
       // QUnit will hang forever if we don't explicitly turn this into
@@ -83,26 +96,6 @@ test('adapter stores the auth token in storage', function(){
       // structure that foils QUnit's eager generation of its failure message
       ok(!!resultForSession.currentUser, 'sets currentUser on session');
       equal(Ember.get(resultForSession, 'currentUser.username'), userEmail, 'user email is from the API');
-    }, function(e){
-      ok(false, "Unexpected error: "+e);
-    });
-  });
-});
-
-test('#close destroys token, storage', function(){
-  var adapter = this.subject();
-
-  var removedKey;
-  storage.remove = function(key){
-    removedKey = key;
-  };
-  auth.token = 'some-token';
-
-  Ember.run(function(){
-    adapter.close().then(function(){
-      ok(true, 'session is opened with an auth_token');
-      equal(removedKey, config.authTokenKey, 'removes token value');
-      ok(!auth.token, 'unsets token on auth');
     }, function(e){
       ok(false, "Unexpected error: "+e);
     });


### PR DESCRIPTION
Paired with:
- https://github.com/aptible/dashboard.aptible.com/pull/313
- https://github.com/aptible/auth.aptible.com/pull/154

Do not use localStorage for keeping a manage token. Fetch the manage token from the server, and destroy it at the server when closing a session.

TODO:
- [x] Cory lands a fix for phantom
- [x] fetch should memoize failure to fetch and not try again
