### PR TITLE
Add helper that is required for dashboard elasticsearch-logdrain-dropdown test

### DIFF
--- a/test-support/helpers/aptible-helpers.js
+++ b/test-support/helpers/aptible-helpers.js
@@ -177,6 +177,16 @@ Ember.Test.registerHelper('stubDatabase', function(app, databaseData){
   });
 });
 
+Ember.Test.registerHelper('stubStackDatabases', function(app, stackId, dbData){
+  stubRequest('get', `/accounts/${stackId}/databases`, function(request){
+    return this.success({
+      _embedded: {
+        databases: dbData
+      }
+    });
+  });
+});
+
 Ember.Test.registerHelper('stubStacks', function(app, options, stacks){
   if (!options) { options = {}; }
   if (options.includeApps === undefined) {


### PR DESCRIPTION
Add helper that is required for dashboard elasticsearch-logdrain-dropdown test. The pull request https://github.com/aptible/dashboard.aptible.com/pull/329 is dependent on this.

cc @mixonic 
