### PR TITLE
Add new log drain fields for elasticsearch support.

### DIFF
--- a/app/models/log_drain.js
+++ b/app/models/log_drain.js
@@ -6,6 +6,8 @@ export default DS.Model.extend(ProvisionableMixin, {
   drainHost: DS.attr('string'),
   drainPort: DS.attr('string'),
   drainType: DS.attr('string'),
+  drainUsername: DS.attr('string'),
+  drainPassword: DS.attr('string'),
 
   stack: DS.belongsTo('stack', {async:true})
 });


### PR DESCRIPTION
Add `drainUsername` and `drainPassword` fields to log drain model. This fields already exists in the API and is a prerequisite for aptible/dashboard.aptible.com#329.
