### PR TITLE
Add compliance helpers to organization

### DIFF
--- a/app/helpers/format-utc-timestamp.js
+++ b/app/helpers/format-utc-timestamp.js
@@ -10,7 +10,7 @@ function padLeft(str, len=2, filler="0"){
   return str;
 }
 
-export function formatUtcTimestamp(date) {
+export function formatUtcTimestamp(date, excludeTime = false) {
   if (!date) { return; }
 
   Ember.assert('format-utc-timestamp must be given an instanceof Date',
@@ -24,7 +24,13 @@ export function formatUtcTimestamp(date) {
   hours = hours > 12 ? (hours-12) : hours;
   let minutes = padLeft(date.getUTCMinutes(), 2, '0');
 
-  return `${month} ${day}, ${year} ${hours}:${minutes}${period} UTC`;
+  let formatted = `${month} ${day}, ${year}`;
+
+  if(!excludeTime) {
+    formatted = `${formatted} ${hours}:${minutes}${period} UTC`;
+  }
+
+  return formatted;
 }
 
 export default Ember.Handlebars.makeBoundHelper(formatUtcTimestamp);

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -32,6 +32,61 @@ export default DS.Model.extend({
   hasStripeSubscription: Ember.computed.bool('stripeSubscriptionId'),
   hasStripeCustomer: Ember.computed.bool('stripeCustomerId'),
   hasStripe: Ember.computed.and('hasStripeCustomer', 'hasStripeSubscription'),
+  managePermissions: Ember.computed.filterBy('permissions', 'scope', 'manage'),
+
+  getCriteriaSubjects(criteria) {
+    let subjects = [];
+    let organization = this;
+
+    criteria.forEach((criterion) => {
+      organization.getCriterionSubjects(criterion).forEach((s) => {
+        subjects.push(s);
+      });
+    });
+
+    return subjects;
+  },
+
+  getCriterionSubjects(criterion) {
+    let prop = { training_log: 'users',
+                 developer_training_log: 'developers',
+                 security_officer_training_log: 'securityOfficer'}[criterion.get('handle')];
+
+    return Ember.makeArray(this.get(prop));
+  },
+
+  developerRoles: Ember.computed('roles.@each.privileged', 'managePermissions', function() {
+    // FIXME: Developer roles are any roles that:
+    // 1. Are privileged: true
+    // 2. Or have a manage permission on an API resource
+    // This property will not be set without first setting permissions on
+    // the organization instance.  This seems smelly.
+
+    let roles = this.get('roles');
+    let permissions = this.get('managePermissions');
+    let managedRolesHrefs = permissions.map((p) => p.get('data.links.role'));
+
+    return roles.filter((role) => {
+      let roleHref = role.get('data.links.self');
+      return role.get('privileged') || managedRolesHrefs.indexOf(roleHref) > -1;
+    });
+  }),
+
+  developers: Ember.computed('developerRoles', 'roles.@each.users', function() {
+    // FIXME: This depends on developerRoles, which requires permissions transient
+    // set on organization instance
+
+    let developerRoles = this.get('developerRoles');
+    let developmentUsers = [];
+
+    developerRoles.forEach((r) => {
+      r.get('users').forEach((u) => {
+        developmentUsers.addObject(u);
+      });
+    });
+    return developmentUsers;
+  }),
+
   // needed by aptible-ability
   permitsRole(role, scope){
     return new Ember.RSVP.Promise( (resolve) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-aptible-shared",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Shared resources for Aptible's Ember Apps",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR adds helper methods to the organization class that make it easier to determine organization subjects for different training criteria.   
