### PR TITLE
Ensure that excludeTime parameter is a boolean.

### DIFF
--- a/app/helpers/format-utc-timestamp.js
+++ b/app/helpers/format-utc-timestamp.js
@@ -26,6 +26,10 @@ export function formatUtcTimestamp(date, excludeTime = false) {
 
   let formatted = `${month} ${day}, ${year}`;
 
+  if (excludeTime != typeof(boolean)) {
+    excludeTime = false;
+  }
+
   if(!excludeTime) {
     formatted = `${formatted} ${hours}:${minutes}${period} UTC`;
   }


### PR DESCRIPTION
Ember/Handlebars will pass an empty object as a default parameter
if no parameters have been explicitly set in the template.
