### PR TITLE
Expanded certificate name, fixed timestamp format

### DIFF
--- a/app/helpers/format-utc-timestamp.js
+++ b/app/helpers/format-utc-timestamp.js
@@ -26,7 +26,7 @@ export function formatUtcTimestamp(date, excludeTime = false) {
 
   let formatted = `${month} ${day}, ${year}`;
 
-  if (excludeTime != typeof(boolean)) {
+  if (typeof(excludeTime) != 'boolean') {
     excludeTime = false;
   }
 

--- a/app/models/certificate.js
+++ b/app/models/certificate.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { formatUtcTimestamp } from '../helpers/format-utc-timestamp';
 
 export default DS.Model.extend({
   // properties
@@ -25,5 +26,12 @@ export default DS.Model.extend({
   apps: DS.hasMany('app', {asyn:true}),
 
   inUse: Ember.computed.gt('vhosts.length', 0),
-  name: Ember.computed.reads('commonName')
+  name: Ember.computed('commonName', 'notBefore', 'notAfter', 'issuerOrganization', function() {
+    const cn = this.get('commonName');
+    const startDate = formatUtcTimestamp(this.get('notBefore'), true);
+    const expiry = formatUtcTimestamp(this.get('notAfter'), true);
+    const organization = this.get('issuerOrganization');
+
+    return `${cn} - Valid: ${startDate}-${expiry} - Issued by: ${organization}`;
+  })
 });


### PR DESCRIPTION
Missed this in previous PR.

The `object-select` component expects a `model.name` attr for rendering select options.  This update expands the certificate name CP to include more unique attrs.

Also fixed a small bug in our date format helper. 
