### PR TITLE
Eliminates the non-toggle link in what appears to be one button to trigger the user-nav

### DIFF
--- a/app/templates/components/dashboard-dropdown.hbs
+++ b/app/templates/components/dashboard-dropdown.hbs
@@ -1,12 +1,7 @@
 <div class="btn-group {{if isOpen 'open'}}">
-
-  {{#if app}}
-    {{#link-to-aptible app=app path=defaultPath class='btn btn-link' active=false}}
-      {{title}}
-    {{/link-to-aptible}}
-  {{else}}
-    {{link-to title defaultPath class="btn btn-link" active=false}}
-  {{/if}}
+  <a href="#" class="btn btn-link" {{action "toggle"}}>
+    {{title}}
+  </a>
 
   <a href="#" class="btn btn-link dropdown-toggle" {{action "toggle"}}>
     <i class="fa fa-chevron-down"></i>


### PR DESCRIPTION
![user-nav-always-toggle](https://cloud.githubusercontent.com/assets/94830/9539714/de13176a-4d12-11e5-96f8-b8e011cc23fa.gif)
Note the screen gif didn't get the subtle header bg gradient, but it's still there. An additional style update is required in dashboard to eliminate a weird `:focus` underline on the linked name when clicking the arrow.

If this looks good, updating dashboard would close https://github.com/aptible/dashboard.aptible.com/issues/418

@sandersonet
