### PR TITLE
Resolve permittables before checking if role is permitted

### DIFF
--- a/app/utils/can.js
+++ b/app/utils/can.js
@@ -1,17 +1,23 @@
 import Ember from 'ember';
 
-export default function can(user, scope, permittable){
-  Ember.assert('Must pass a parameter that implements `permitsRole`',
-               !!permittable.permitsRole);
-
-  if (scope === "read" || user.get('verified')) {
-    return user.get('roles').then(function(roles){
-      return Ember.RSVP.all(roles.map((role) => permittable.permitsRole(role, scope)) );
-    }).then((results) => {
-      return results.indexOf(true) > -1;
-    });
-  } else {
+export default function can(user, scope, permittablePromise){
+  if(scope === 'manage' && !user.get('verified')) {
     return Ember.RSVP.resolve(false);
   }
+
+  let permittable;
+
+  return new Ember.RSVP.Promise(function(resolve) {
+    // Ensure permittable is resolved as a model and not a promise
+    resolve(permittablePromise);
+  }).then(function(resolvedPermittable) {
+    Ember.assert('Must pass a parameter that implements `permitsRole`', !!resolvedPermittable.permitsRole);
+    permittable = resolvedPermittable;
+    return user.get('roles');
+  }).then(function(roles){
+    return Ember.RSVP.all(roles.map((role) => permittable.permitsRole(role, scope)) );
+  }).then((results) => {
+    return results.indexOf(true) > -1;
+  });
 
 }

--- a/app/utils/can.js
+++ b/app/utils/can.js
@@ -7,10 +7,8 @@ export default function can(user, scope, permittablePromise){
 
   let permittable;
 
-  return new Ember.RSVP.Promise(function(resolve) {
-    // Ensure permittable is resolved as a model and not a promise
-    resolve(permittablePromise);
-  }).then(function(resolvedPermittable) {
+  return new Ember.RSVP.resolve(permittablePromise)
+  .then(function(resolvedPermittable) {
     Ember.assert('Must pass a parameter that implements `permitsRole`', !!resolvedPermittable.permitsRole);
     permittable = resolvedPermittable;
     return user.get('roles');


### PR DESCRIPTION
Permission checks currently fail if the `permittable` hasn't resolved yet.  `user.can` is already promise-based, so this PR updated `user.can` to resolve `permittable` before attempting to verify the current role is permitted.
