### PR TITLE
Patch links directly on to payload for any belongsTo

### DIFF
--- a/app/serializers/app.js
+++ b/app/serializers/app.js
@@ -1,21 +1,6 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  normalize() {
-    var payload = this._super(...arguments);
-
-    if (!(payload && payload.links && payload.links.stack)) {
-      return payload;
-    }
-
-    var stackHrefParts = payload.links.stack.split('/');
-    var stackId = stackHrefParts[stackHrefParts.length - 1];
-
-    payload.stack = stackId;
-
-    return payload;
-  },
-
   attrs: {
     status: {serialize: false},
     account: {serialize: false},


### PR DESCRIPTION
@rwjblue - This will fill some gaps with our out-of-date ED and HAL9000 by transposing all `belongsTo`'s onto the payload body if a link exists.  I essentially took the fix you applied to `app` specifically and generalized it for the entire `ApplicationSerializer`
