### PR TITLE
Don't load certs for common name

### DIFF
--- a/app/models/vhost.js
+++ b/app/models/vhost.js
@@ -17,9 +17,7 @@ export default DS.Model.extend(ProvisionableMixin, {
 
   reloadWhileProvisioning: true,
 
-  commonName: Ember.computed('certificate.commonName', 'virtualDomain', function() {
-    return this.get('certificate.commonName') || this.get('virtualDomain')
-  }),
+  commonName: Ember.computed.alias('virtualDomain'),
   displayHost: Ember.computed('isDefault', 'externalHost', 'virtualDomain', function() {
     if(this.get('isDefault')) {
       return this.get('virtualDomain');


### PR DESCRIPTION
Currently we burn a request for the vhost's certificate just to show a common name.  This is unnecessary as the [API already did this](https://github.com/aptible/api.aptible.com/blob/master/app/decorators/vhost_decorator.rb#L5) for us with `vhost.virtualDomain`.
