### PR TITLE
Reload belongs to

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -54,17 +54,16 @@ export default HalAdapter.extend({
   // directly from the server.  This patch changes that behavior to first
   // see if the record is already loaded in store.  If so, that record is
   // resolved immediately and a request is never made.
-  findBelongsTo(store, link, relationshipPath) {
-    // relationshipPath: users/id
+  findBelongsTo(store, snapshot, relationshipPath, metaForProperty) {
     let segments = relationshipPath.split('/');
     let id = segments[segments.length - 1];
-    let modelName = Ember.String.singularize(segments[segments.length - 2]);
+    let modelName = metaForProperty.type.modelName;
     let payload;
 
     modelName = modelNameFromPayloadKey(modelName);
     payload = this._payloadFromCache(modelName, id, store);
 
-    if(payload) {
+    if(!metaForProperty.requireReload && payload) {
       return Ember.RSVP.resolve(payload);
     } else {
       return this._super(...arguments);
@@ -84,3 +83,4 @@ export default HalAdapter.extend({
     return payload;
   }
 });
+

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -2,5 +2,5 @@ import DS from "ember-data";
 
 export default DS.Model.extend({
   accessToken: DS.attr('string'),
-  user: DS.belongsTo('user', {async: true})
+  user: DS.belongsTo('user', { async: true, requireReload: true })
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -18,7 +18,7 @@ export default DS.Model.extend({
   passwordConfirmation: null,
 
   // relationships
-  token: DS.belongsTo('token', {async: true}),
+  token: DS.belongsTo('token', { async: true, requireReload: true }),
   roles: DS.hasMany('role', {async:true}),
   sshKeys: DS.hasMany('ssh-key', {async:true}),
 


### PR DESCRIPTION
cc @rwjblue -- This patches `findBelongsTo` to check relationship options for `requreReload:true`.  If true, this will skip loading from cache and instead load from the server.
