### PR TITLE
add findQuery to all stack resources

### DIFF
--- a/app/adapters/app.js
+++ b/app/adapters/app.js
@@ -1,14 +1,1 @@
-import StackResource from './stack-resource';
-
-export default StackResource.extend({
-  findQuery: function(store, type, query) {
-    let url = this.buildURL(type.modelName, null, null, 'findQuery');
-
-    if (query.stack) {
-      url = url.replace('/apps', `/accounts/${query.stack.id}/apps`);
-      delete query.stack;
-    }
-
-    return this.ajax(url, 'GET', {data:query});
-  }
-});
+export { default } from './stack-resource';

--- a/app/adapters/stack-resource.js
+++ b/app/adapters/stack-resource.js
@@ -3,6 +3,19 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'accounts': {property: 'stack.id', only: ['create']}
-  })
+    'accounts': {property: 'stack.id', only: ['create', 'findquery']}
+  }),
+
+  findQuery(store, type, query) {
+    if(!query.stack) {
+      return this._super(...arguments);
+    }
+
+    let record = store.createRecord(type.modelName, { stack: query.stack });
+    let url = this.buildURL(type.modelName, null, { record: record }, 'findquery');
+
+    record.rollback();
+    delete query.stack
+    return this.ajax(url, 'GET', { data: query });
+  }
 });

--- a/tests/unit/adapters/app-adapter.js
+++ b/tests/unit/adapters/app-adapter.js
@@ -1,0 +1,37 @@
+import {
+  test,
+  moduleFor
+} from 'ember-qunit';
+import DS from "ember-data";
+import Ember from "ember";
+import { stubRequest } from 'ember-cli-fake-server';
+import modelDeps from '../../support/common-model-dependencies';
+
+var container, store;
+
+moduleFor('adapter:app', 'AppAdapter', {
+  needs: modelDeps.concat([
+    'store:application',
+    'serializer:application'
+  ]),
+  setup: function(){
+    var container = this.container;
+    store = container.lookup('store:application');
+  }
+});
+
+test('findQuery uses correct URL', function(assert) {
+  var done = assert.async();
+  assert.expect(1);
+
+  stubRequest('get', '/accounts/my-stack-1/databases', function() {
+    assert.ok(true, 'uses correct URL');
+    done();
+    return this.success({});
+  });
+
+  Ember.run(function() {
+    var stack = store.createRecord('stack', { id: 'my-stack-1' });
+    store.find('app', { stack: stack });
+  });
+});

--- a/tests/unit/adapters/database-test.js
+++ b/tests/unit/adapters/database-test.js
@@ -1,0 +1,37 @@
+import {
+  test,
+  moduleFor
+} from 'ember-qunit';
+import DS from "ember-data";
+import Ember from "ember";
+import { stubRequest } from 'ember-cli-fake-server';
+import modelDeps from '../../support/common-model-dependencies';
+
+var container, store;
+
+moduleFor('adapter:database', 'DatabaseAdapter', {
+  needs: modelDeps.concat([
+    'store:application',
+    'serializer:application'
+  ]),
+  setup: function(){
+    var container = this.container;
+    store = container.lookup('store:application');
+  }
+});
+
+test('findQuery uses correct URL', function(assert) {
+  var done = assert.async();
+  assert.expect(1);
+
+  stubRequest('get', '/accounts/my-stack-1/databases', function() {
+    assert.ok(true, 'uses correct URL');
+    done();
+    return this.success({});
+  });
+
+  Ember.run(function() {
+    var stack = store.createRecord('stack', { id: 'my-stack-1' });
+    store.find('database', { stack: stack });
+  });
+});


### PR DESCRIPTION
This PR fixes https://github.com/aptible/dashboard.aptible.com/issues/465 by moving AppAdapter's `findQuery` logic to the `StackResource` abstract adapter.

A temporary resource is stubbed in order to allow us to leverage `buildURLWithPrefixMap` rather than trying to do URL replacements for all stack resources.

cc @rwjblue  
