### PR TITLE
Added wait of 3s to the clipboard tooltip removal.

### DIFF
--- a/app/components/click-to-copy/component.js
+++ b/app/components/click-to-copy/component.js
@@ -42,6 +42,6 @@ export default Ember.Component.extend({
       if (!this.isDestroying && !this.isDestroyed) {
         this.set('isTooltipped', false);
       }
-    });
+    }, 3000);
   }
 });


### PR DESCRIPTION
Without this the tooltip after copying to clipboard gets closed out immediately. It's a real problem in the unsupported browser (safari) situation where the tip says `Press ⌘+C to copy`.
