### PR TITLE
SPD modals

### DIFF
--- a/app/components/modal-wrapper/component.js
+++ b/app/components/modal-wrapper/component.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actions: {
+    onDismiss() {
+      this.sendAction('onDismiss');
+    }
+  }
+});

--- a/app/styles/_modals.scss
+++ b/app/styles/_modals.scss
@@ -1,0 +1,88 @@
+.lm-container {
+  cursor: default;
+}
+
+.lf-overlay {
+  background-color: #fff;
+  opacity: .95
+}
+
+.lf-dialog {
+  width: 600px;
+  max-width: 600px;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.modal-header {
+  border: 0;
+  padding: 0;
+  margin: 0 0 30px;
+
+  .modal-title {
+    font-size: 20px;
+    margin: 0 50px 30px 0;
+    color: $color-primary;
+  }
+
+  .modal-description {
+    font-size: 14px;
+    color: $color-light;
+  }
+}
+
+.modal-body {
+  padding: 0;
+
+  label {
+    font-size: 15px;
+  }
+
+  .panel-body {
+    padding: 30px;
+  }
+
+  .form-group {
+    margin-bottom: 30px;
+  }
+}
+
+.modal-dismiss {
+  float: right;
+  cursor: pointer;
+
+  .modal-esc {
+    opacity: 0;
+    float: left;
+    margin: 14px 8px 0 0;
+    color: $color-light;
+    text-transform: uppercase;
+    font-size: 10px;
+    font-weight: $weight-semibold;
+    transition-duration: 200ms;
+  }
+
+  .modal-times {
+    color: $color-light;
+    font-size: 30px;
+    transition-duration: 200ms;
+  }
+
+  &:hover {
+    .modal-esc {
+      opacity: 1;
+    }
+
+    .modal-times {
+      color: $color-primary;
+    }
+  }
+}
+
+.modal-body .panel-default {
+  background: #FFFFFF;
+  border: 1px solid #E0E0E0;
+  box-shadow: 0px 1px 4px 0px rgba(0,0,0,0.08);
+  border-radius: 3px;
+}

--- a/app/styles/aptible.scss
+++ b/app/styles/aptible.scss
@@ -11,7 +11,10 @@
 @import "header";
 @import "input-validation";
 @import "layout";
+@import "modals";
 @import "panels";
 @import "sidebar";
-@import "components/click-to-copy";
 @import "tables";
+
+
+@import "components/click-to-copy";

--- a/app/templates/components/modal-wrapper.hbs
+++ b/app/templates/components/modal-wrapper.hbs
@@ -1,0 +1,19 @@
+<div class="modal-container">
+  <div class="modal-header">
+    <div class="modal-dismiss" {{action "onDismiss"}}>
+      <span class="modal-esc">
+        ESC
+      </span>
+      <span class="modal-times">
+        &times;
+      </span>
+    </div>
+
+    <h1 class="modal-title">{{title}}</h1>
+    <div class="modal-description">{{description}}</div>
+  </div>
+
+  <div class="modal-body">
+    {{yield}}
+  </div>
+</div>

--- a/tests/unit/components/modal-wrapper-test.js
+++ b/tests/unit/components/modal-wrapper-test.js
@@ -1,0 +1,19 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('modal-wrapper', 'ModalWrapperComponent', {
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
This PR ads some nice styles and a modal helper component that wraps modal content in consistent chrome.

Example modal:

<img width="833" alt="screenshot 2015-11-24 09 58 15" src="https://cloud.githubusercontent.com/assets/884151/11370473/ee9aee54-9291-11e5-8d59-307414728350.png">

Example implementation from SPD:

``` hbs
{{#modal-wrapper title="Add a location" description=description onDismiss="onDismiss"}}
  <div class="panel panel-default white-panel">
    <div class="panel-body">
      <form>
        {{#if errors}}
          <div class="alert alert-danger">
            {{errors}}
            <button {{action "clearMessages"}} type="button" class="close">
              <span aria-hidden="true">&times;</span>
            </button>
          </div>
        {{/if}}

        {{#each-property properties=locationProperties as |key property type|}}
          <div class="form-group">
            <label>{{property.displayProperties.title}}</label>
            {{component (concat 'schema-field-' type) key=key property=property document=newLocation}}
          </div>
        {{/each-property}}

        <button class="btn btn-default btn-lg pull-right" type="reset" {{action "onDismiss"}}>Cancel</button>
        <button class="btn btn-primary btn-lg" type="submit" {{action "addLocation" newLocation}}>Add Location</button>
      </form>
    </div>
  </div>
{{/modal-wrapper}}
```
