### PR TITLE
Adds new billing API fields to BillingDetail

### DIFF
--- a/app/models/billing-detail.js
+++ b/app/models/billing-detail.js
@@ -53,15 +53,15 @@ export default DS.Model.extend({
   hasStripeSubscription: Ember.computed.bool('stripeSubscriptionId'),
   hasStripeCustomer: Ember.computed.bool('stripeCustomerId'),
   hasStripe: Ember.computed.and('hasStripeCustomer', 'hasStripeSubscription'),
+  accountBalance: DS.attr('number'),
+  planRate: DS.attr('number'),
+  coupon: DS.attr(),
 
   // Temporary rate and allowance stubs until these are fulfilled with
   // customer-specific values from Billing API
   containerCentsPerHour: CONTAINER_CENTS_PER_HOUR,
   diskCentsPerHour: DISK_CENTS_PER_HOUR,
   domainCentsPerHour: DOMAIN_CENTS_PER_HOUR,
-  planRate: Ember.computed('plan', function() {
-    return PLAN_RATES[this.get('plan')];
-  }),
 
   containersInPlan: Ember.computed('containerAllowance', 'plan', function() {
     return this.get('containerAllowance') || CONTAINER_ALLOWANCES[this.get('plan')] || 0;
@@ -73,5 +73,20 @@ export default DS.Model.extend({
 
   domainsInPlan: Ember.computed('domainAllowance', 'plan', function() {
     return this.get('domainAllowance') || DOMAIN_ALLOWANCES[this.get('plan')] || 0;
+  }),
+
+  hasCredit: Ember.computed('accountBalance', function() {
+    return this.get('accountBalance') < 0;
+  }),
+
+  accountCredit: Ember.computed('accountBalance', function() {
+    if (this.get('hasCredit')) {
+      return -1 * this.get('accountBalance');
+    }
+    return 0;
+  }),
+
+  hasDiscounts: Ember.computed('accountBalance', 'coupon', function() {
+    return this.get('hasCredit') || !!this.get('coupon');
   })
 });

--- a/app/models/billing-detail.js
+++ b/app/models/billing-detail.js
@@ -79,14 +79,14 @@ export default DS.Model.extend({
     return this.get('accountBalance') < 0;
   }),
 
-  accountCredit: Ember.computed('accountBalance', function() {
+  accountCredit: Ember.computed('accountBalance', 'hasCredit', function() {
     if (this.get('hasCredit')) {
       return -1 * this.get('accountBalance');
     }
     return 0;
   }),
 
-  hasDiscounts: Ember.computed('accountBalance', 'coupon', function() {
+  hasDiscounts: Ember.computed('hasCredit', 'coupon', function() {
     return this.get('hasCredit') || !!this.get('coupon');
   })
 });

--- a/tests/unit/models/billing-detail-test.js
+++ b/tests/unit/models/billing-detail-test.js
@@ -86,6 +86,18 @@ test('it correctly sets domainsInPlan', function(assert) {
   assert.equal(model.get('domainsInPlan'), 20);
 });
 
+test('it inverts accountBalance for accountCredit', function(assert) {
+  var model = this.subject();
+  setupModel(model, { accountBalance: -50000 });
+  assert.strictEqual(model.get('accountCredit'), 50000);
+
+  setupModel(model, { accountBalance: 0 });
+  assert.strictEqual(model.get('accountCredit'), 0);
+
+  setupModel(model, { accountBalance: 10000 });
+  assert.strictEqual(model.get('accountCredit'), 0);
+});
+
 test('it correctly determines hasCredit', function(assert) {
   var model = this.subject();
   setupModel(model, { accountBalance: -50000 });

--- a/tests/unit/models/billing-detail-test.js
+++ b/tests/unit/models/billing-detail-test.js
@@ -85,3 +85,28 @@ test('it correctly sets domainsInPlan', function(assert) {
   setupModel(model, { plan: 'platform', domainAllowance: 20 });
   assert.equal(model.get('domainsInPlan'), 20);
 });
+
+test('it correctly determines hasCredit', function(assert) {
+  var model = this.subject();
+  setupModel(model, { accountBalance: -50000 });
+  assert.strictEqual(model.get('hasCredit'), true);
+
+  setupModel(model, { accountBalance: 0 });
+  assert.strictEqual(model.get('hasCredit'), false);
+
+  setupModel(model, { accountBalance: 10000 });
+  assert.strictEqual(model.get('hasCredit'), false);
+});
+
+test('it correctly determines hasDiscounts', function(assert) {
+  var model = this.subject();
+
+  setupModel(model, { accountBalance: -50000 });
+  assert.strictEqual(model.get('hasDiscounts'), true);
+
+  setupModel(model, { accountBalance: 10000 });
+  assert.strictEqual(model.get('hasDiscounts'), false);
+
+  setupModel(model, { accountBalance: 0, coupon: { amountOff: 10000 } });
+  assert.strictEqual(model.get('hasDiscounts'), true);
+});


### PR DESCRIPTION
`BillingDetail` now includes:
- `accountBalance` to show remaining credit
- `planRate` to clear up confusion for current Platform plan holders
  paying the old price
- `coupon` is a JSON object with more data (percentage vs flat discount)

Also adds some helpers.
More progress on https://github.com/aptible/billing.aptible.com/issues/71

@sandersonet 
