### PR TITLE
`--initialize-from` support

### DIFF
--- a/app/models/database.js
+++ b/app/models/database.js
@@ -14,8 +14,17 @@ export default DS.Model.extend(ProvisionableMixin, {
   stack: DS.belongsTo('stack', {async: true}),
   operations: DS.hasMany('operation', {async:true}),
   disk: DS.belongsTo('disk', {async:true}),
+  initializeFrom: DS.belongsTo('database', {async: true, inverse: 'dependents'}),
+  dependents: DS.hasMany('database', {async: true, inverse: 'initializeFrom'}),
 
-  reloadWhileProvisioning: true
+  reloadWhileProvisioning: true,
+
+  supportsReplication: Ember.computed('type', function () {
+    let type = this.get('type');
+    return (type === 'redis' ||
+            type === 'postgresql' ||
+            type === 'mysql');
+  })
 });
 
 export function provisionDatabases(user, store){

--- a/app/styles/_dashboard.scss
+++ b/app/styles/_dashboard.scss
@@ -44,6 +44,11 @@ header.resource-header {
           margin: 0 0 0 10px;
         }
       }
+
+      .resource-affix {
+        font-size: 16px;
+        color: $color-light;
+      }
     }
 
     .resource-icon {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-pretender": "^0.3.1",
-    "ember-data-hal-9000": "~0.2.0",
+    "ember-data-hal-9000": "~0.2.1",
     "ember-inflector": "^1.6.2"
   },
   "ember-addon": {


### PR DESCRIPTION
This adds support for the new attributes that are being added in https://github.com/aptible/api.aptible.com/pull/304. It also adds some styling support for an incoming PR in Dashboard.

I haven't added tests here, because this is indirectly exercised in the Dashboard PR (and it's largely declarative anyway), but let me know if I should! :smile: 

I'm not 100% happy about hard-coding the logic of what DBs support replication here, but I can't think of a much better solution: the API doesn't know either (only the DB images do). I guess I could argue that "which DBs support replication" is purely presentational and deserves to be here... but let me know your thoughts!
## 

Note: this shouldn't be merged in until https://github.com/aptible/api.aptible.com/pull/304 is live.

cc @fancyremarker @sandersonet @gib 
