### PR TITLE
Add support for clustered databases

### DIFF
--- a/app/models/database.js
+++ b/app/models/database.js
@@ -24,7 +24,9 @@ export default DS.Model.extend(ProvisionableMixin, {
     return (type === 'redis' ||
             type === 'postgresql' ||
             type === 'mysql');
-  })
+  }),
+
+  supportsClustering: Ember.computed.equal('type', 'mongodb')
 });
 
 export function provisionDatabases(user, store){


### PR DESCRIPTION
A small tweak to support the fact that MongoDB now supports `--initialize-from`!

---

The UI should behave a little differently for databases that support
replication and databases that support clustering. For example,
while it's fine to daisy-chain replicated databases, it doesn't really
make sense to do so in the clustered case. Furthermore, the terminology
is different.

Note that since the backend doesn't really understand the difference
between clustering and replication (all it cares about is what existing
database the new one should initialize from), it's worth trying to keep
the relationships in good order on the frontend (i.e. avoid
daisy-chaining in the clustered scenario), but it's not stricly-speaking
required for things to work.
