### PR TITLE
Add containerMemoryLimitMb

### DIFF
--- a/app/models/operation.js
+++ b/app/models/operation.js
@@ -12,7 +12,8 @@ export default DS.Model.extend({
   diskSize: DS.attr('number'),
 
   // scaling services
-  containerCount: DS.attr('number'), // when scaling a service
+  containerSize: DS.attr('number'), // when scaling size of container
+  containerCount: DS.attr('number'), // when scaling number of containers
 
   // vhosts
   certificate: DS.attr(),

--- a/app/models/service.js
+++ b/app/models/service.js
@@ -8,5 +8,10 @@ export default DS.Model.extend({
   handle: DS.attr('string'),
   command: DS.attr('string'),
   containerCount: DS.attr('number'),
-  processType: DS.attr('string')
+  containerMemoryLimitMb: DS.attr('number'),
+  processType: DS.attr('string'),
+
+  containerSize: Ember.computed('containerMemoryLimitMb', function() {
+    return this.get('containerMemoryLimitMb') || 1024;
+  })
 });

--- a/app/models/stack.js
+++ b/app/models/stack.js
@@ -17,6 +17,7 @@ export default DS.Model.extend({
   syslogHost: DS.attr('string'),
   syslogPort: DS.attr('string'),
   organizationUrl: DS.attr('string'),
+  sweetnessStackVersion: DS.attr('string'),
   activated: DS.attr('boolean'),
   containerCount: DS.attr('number'),
   appContainerCount: DS.attr('number'),


### PR DESCRIPTION
Adds `containerMemoryLimitMb`, along with a computed `containerSize`.
Required for aptible/dashboard.aptible.com#534.

cc @sandersonet @gib 
