### PR TITLE
Support actor tokens

### DIFF
--- a/app/application/torii-adapter.js
+++ b/app/application/torii-adapter.js
@@ -17,7 +17,8 @@ function pushTokenToStore(tokenPayload, store) {
     accessToken: tokenPayload.access_token,
     rawPayload: JSON.stringify(tokenPayload),
     links: {
-      user: tokenPayload._links.user.href
+      user: tokenPayload._links.user.href,
+      actor: tokenPayload._links.actor && tokenPayload._links.actor.href
     }
   });
 }
@@ -33,7 +34,8 @@ export default Ember.Object.extend({
     }).then((token) => {
       return Ember.RSVP.hash({
         token,
-        currentUser: token.get('user')
+        currentUser: token.get('user'),
+        currentActor: token.get('actor')
       });
     }).then((session) => {
       // Load role eagerly

--- a/app/application/torii-provider.js
+++ b/app/application/torii-provider.js
@@ -1,9 +1,17 @@
+import Ember from 'ember';
 import BaseProvider from "torii/providers/base";
 import ajax from "../utils/ajax";
 import config from "../config/environment";
 
 export default BaseProvider.extend({
   open(credentials) {
+    // If the credential has a "token", we just pass it right through
+    // TODO: Check that it's an actual token object instead?
+    let token = credentials.token;
+    if (token !== undefined) {
+      return new Ember.RSVP.Promise((resolve, _) => resolve(JSON.parse(token.get('rawPayload'))));
+    }
+
     return ajax(config.authBaseUri+'/tokens', {
       type: 'POST',
       data: credentials,

--- a/app/components/dashboard-dropdown/component.js
+++ b/app/components/dashboard-dropdown/component.js
@@ -4,6 +4,15 @@ export default Ember.Component.extend({
   className: ['dashboard-dropdown'],
   isOpen: false,
 
+  title: Ember.computed('user.name', 'actor.name',  function () {
+    let userName = this.get('user.name'),
+        actorName = this.get('actor.name');
+    if (actorName) {
+      return `${actorName} (as ${userName})`;
+    }
+    return userName;
+  }),
+
   init: function(){
     this._super();
     this.eventName = 'click.'+Ember.guidFor(this);

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -2,5 +2,6 @@ import DS from "ember-data";
 
 export default DS.Model.extend({
   accessToken: DS.attr('string'),
-  user: DS.belongsTo('user', { async: true, requireReload: true })
+  user: DS.belongsTo('user', { async: true, requireReload: true }),
+  rawPayload: DS.attr('string')
 });

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -2,6 +2,7 @@ import DS from "ember-data";
 
 export default DS.Model.extend({
   accessToken: DS.attr('string'),
-  user: DS.belongsTo('user', { async: true, requireReload: true }),
+  user: DS.belongsTo('user', { async: true, requireReload: true, inverse: 'token'}),
+  actor: DS.belongsTo('user', { async: true, requireReload: true }),
   rawPayload: DS.attr('string')
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -9,6 +9,7 @@ export default DS.Model.extend({
   password: DS.attr('string'),
   verified: DS.attr('boolean'),
   createdAt: DS.attr('date'),
+  superuser : DS.attr('boolean'),
 
   // used when changing a user's password. Set as an `attr` so that it
   // will be sent to the API

--- a/app/templates/-focus-header.hbs
+++ b/app/templates/-focus-header.hbs
@@ -6,7 +6,7 @@
   <nav>
     <ul class="nav nav-pills navbar-right user-nav">
       <li class="dropdown current-user">
-        {{#dashboard-dropdown title=session.currentUser.name defaultPath="settings"}}
+        {{#dashboard-dropdown user=session.currentUser actor=session.currentActor defaultPath="settings"}}
 
           {{#each session.currentUser.organizations as |organization|}}
             {{dashboard-dropdown-organization-menu organization=organization}}

--- a/app/templates/-header.hbs
+++ b/app/templates/-header.hbs
@@ -17,7 +17,7 @@
   <nav>
     <ul class="nav nav-pills navbar-right user-nav">
       <li class="dropdown current-user">
-        {{#dashboard-dropdown title=session.currentUser.name defaultPath="settings" app="dashboard"}}
+        {{#dashboard-dropdown user=session.currentUser actor=session.currentActor defaultPath="settings" app="dashboard"}}
 
           {{#each session.currentUser.organizations as |organization|}}
             {{dashboard-dropdown-organization-menu organization=organization app="dashboard"}}

--- a/app/templates/components/dashboard-dropdown-user-menu.hbs
+++ b/app/templates/components/dashboard-dropdown-user-menu.hbs
@@ -20,6 +20,14 @@
   {{/link-to-aptible}}
 {{/dashboard-dropdown-item}}
 
+{{#if user.superuser}}
+{{#dashboard-dropdown-item}}
+  {{#link-to-aptible path='settings/impersonate' app='dashboard'}}
+    Impersonate
+  {{/link-to-aptible}}
+{{/dashboard-dropdown-item}}
+{{/if}}
+
 {{dashboard-dropdown-divider}}
 
 <div>


### PR DESCRIPTION
This adds support for actor tokens (and superusers that can generate them in the first place). 

The following changes are mainly here to support changes in dashboard:
- Store the raw payload received from the API as token so we can easily re-auth with a token from the store.
- Optionally do not delete the token when logging out.

The following do stand on their own:
- Show a link to the impersonation menu if the user is a superuser (i.e. if they may be able to use it in the first place).
- Add actor-awareness (renders as `$ActorName (as $Username)` in the navbar)
## 

cc @fancyremarker @sandersonet @gib 
