### PR TITLE
Adds CSS for a flex box meta data header option

### DIFF
--- a/app/styles/_dashboard.scss
+++ b/app/styles/_dashboard.scss
@@ -178,6 +178,25 @@ header.resource-header {
   }
 }
 
+// Flex box header row option to keep columns from wrapping
+header.resource-header .resource-metadata--flex {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  width: 100%;
+  .resource-metadata-item {
+    min-width: 0;
+    float: none;
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
+  .resource-metadata-title {
+    white-space: nowrap;
+  }
+}
+
 .panel-body {
   .resource-metadata-item {
   }


### PR DESCRIPTION
This allows text in columns to wrap without wrapping the columns themselves. Part of a fix for https://github.com/aptible/dashboard.aptible.com/issues/530

<img width="1275" alt="screen shot 2016-02-29 at 7 10 34 pm" src="https://cloud.githubusercontent.com/assets/94830/13415471/726af224-df18-11e5-9f70-13e3a8410bd7.png">
