### PR TITLE
Leap Day Debacle

### DIFF
--- a/app/helpers/format-utc-timestamp.js
+++ b/app/helpers/format-utc-timestamp.js
@@ -16,7 +16,7 @@ export function formatUtcTimestamp(date, excludeTime = false) {
   Ember.assert('format-utc-timestamp must be given an instanceof Date',
                date instanceof Date);
 
-  let month = monthNames[ date.getMonth() ];
+  let month = monthNames[ date.getUTCMonth() ];
   let day   = date.getUTCDate();
   let year  = date.getUTCFullYear();
   let hours = date.getUTCHours();

--- a/tests/unit/helpers/format-utc-timestamp-test.js
+++ b/tests/unit/helpers/format-utc-timestamp-test.js
@@ -10,14 +10,17 @@ test('it displays in Month, Day Year HH:MMam/pm UTC format', function(assert) {
   let isoCreatedAtPM = '2014-03-19T21:15:33.836Z';
   let isoCreatedAtSingleDigitMinutes = '2014-03-19T21:02:33.836Z';
   let isoCreatedAtDoubleDigitHour = '2014-03-19T11:12:33.836Z';
+  let isoLeapDay = '2016-03-01T00:23:09Z';
 
   let amResult = formatUtcTimestamp( new Date(isoCreatedAtAM) );
   let pmResult = formatUtcTimestamp( new Date(isoCreatedAtPM) );
   let singleDigitResult = formatUtcTimestamp( new Date(isoCreatedAtSingleDigitMinutes) );
   let doubleDigitResult = formatUtcTimestamp( new Date(isoCreatedAtDoubleDigitHour) );
+  let leadDayResult = formatUtcTimestamp( new Date(isoLeapDay) );
 
   assert.equal(amResult, 'March 19, 2014 9:15AM UTC');
   assert.equal(pmResult, 'March 19, 2014 9:15PM UTC');
   assert.equal(singleDigitResult, 'March 19, 2014 9:02PM UTC');
   assert.equal(doubleDigitResult, 'March 19, 2014 11:12AM UTC');
+  assert.equal(leadDayResult, 'March 1, 2016 0:23AM UTC');
 });


### PR DESCRIPTION
Closes https://github.com/aptible/dashboard.aptible.com/issues/537

Uses `getUTCMonth()` to correct a leap day error that was off by one. I found the reported operation and used its ISO timestamp value to do a red/green refactor.
