### PR TITLE
Fix position notifications

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -85,6 +85,11 @@
 }
 
 .notifications {
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1001;
   .alert {
     border-radius: 0;
     margin: 0;


### PR DESCRIPTION
Allows notifications to be seen, fixed to the top of the viewport, when the header is scrolled out of view on long pages.

Closes: https://github.com/aptible/dashboard.aptible.com/issues/533

![fixed-notifications](https://cloud.githubusercontent.com/assets/94830/13513519/a24b988e-e15e-11e5-8a55-8fadb4a25f09.gif)
