### PR TITLE
Only prefix operation parent for create and index

### DIFF
--- a/app/adapters/operation.js
+++ b/app/adapters/operation.js
@@ -3,11 +3,11 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'databases':   {property: 'database.id'},
-    'apps':        {property: 'app.id'},
-    'vhosts':      {property: 'vhost.id'},
-    'log_drains':  {property: 'logDrain.id'},
-    'services':    {property: 'service.id'}
+    'databases':   {property: 'database.id', only:['create', 'index']},
+    'apps':        {property: 'app.id', only:['create', 'index']},
+    'vhosts':      {property: 'vhost.id', only:['create', 'index']},
+    'log_drains':  {property: 'logDrain.id', only:['create', 'index']},
+    'services':    {property: 'service.id', only:['create', 'index']}
   }),
 
   findQuery: function(store, type, query){


### PR DESCRIPTION
 This commit should only prefix the parent path for an operation
 for create or index paths. This means that for example if the parent
 is a service the show method goes directly to `/operations/{id}`
 instead of `/services/{id}/operations/{id}`.

cc @sandersonet 
