### PR TITLE
Add container and release models

### DIFF
--- a/app/models/container.js
+++ b/app/models/container.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  release: DS.belongsTo('release', {async:true}),
+  dockerName: DS.attr('string'),
+  layer: DS.attr('string'),
+  memoryLimit: DS.attr('number')
+});
+

--- a/app/models/database.js
+++ b/app/models/database.js
@@ -16,6 +16,7 @@ export default DS.Model.extend(ProvisionableMixin, {
   disk: DS.belongsTo('disk', {async:true}),
   initializeFrom: DS.belongsTo('database', {async: true, inverse: 'dependents'}),
   dependents: DS.hasMany('database', {async: true, inverse: 'initializeFrom'}),
+  service: DS.belongsTo('service', {async:true}),
 
   reloadWhileProvisioning: true,
 

--- a/app/models/release.js
+++ b/app/models/release.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  containers: DS.hasMany('container', {async:true}),
+  service: DS.belongsTo('service', {async:true})
+});

--- a/app/models/service.js
+++ b/app/models/service.js
@@ -11,6 +11,8 @@ export default DS.Model.extend({
   containerMemoryLimitMb: DS.attr('number'),
   processType: DS.attr('string'),
 
+  currentRelease: DS.belongsTo('release', {async:true}),
+
   containerSize: Ember.computed('containerMemoryLimitMb', function() {
     return this.get('containerMemoryLimitMb') || 1024;
   })


### PR DESCRIPTION
This teaches databases and apps about their underlying releases and containers, so that we can display fancy memory utilization graphs for those (the UI needs to know about their IDs to do so).

cc @sandersonet @gib @fancyremarker 
