### PR TITLE
Frame busting and file drops in textareas

### DIFF
--- a/addon/utils/frame-buster.js
+++ b/addon/utils/frame-buster.js
@@ -1,0 +1,12 @@
+//
+// Dashboard should not be allowed in frames on other sites
+//
+// Preferred method to address this would be setting an X-Frame-Options header,
+// but this is not currently supported by S3
+// https://forums.aws.amazon.com/thread.jspa?threadID=149569
+//
+export default function bustFrames() {
+  if (top.location !== location) {
+    top.location.href = document.location.href;
+  }
+}

--- a/app/components/file-textarea/component.js
+++ b/app/components/file-textarea/component.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+//
+// Appends a textarea with the contents of whatever file was dropped on it.
+//
+export default Ember.Component.extend({
+  classNameBindings: ['dropTargetActive'],
+
+  dropTargetActive: false,
+
+  doneReading: function(event) {
+    let file = event.target;
+    this.set('value', Ember.getWithDefault(this, 'value', '') + file.result);
+  },
+
+  dragEnter: function() {
+    this.set('dropTargetActive', true);
+  },
+
+  dragLeave: function() {
+    this.set('dropTargetActive', false);
+  },
+
+  drop: function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    this.set('dropTargetActive', false);
+    for (var i in event.dataTransfer.files) {
+      try {
+        let reader = new FileReader();
+        let file = event.dataTransfer.files[i];
+
+        reader.onload = Ember.run.bind(this, this.doneReading);
+        reader.readAsText(file);
+      }
+      catch(error) {}
+    }
+  }
+});

--- a/app/styles/aptible.scss
+++ b/app/styles/aptible.scss
@@ -18,5 +18,6 @@
 
 
 @import "components/click-to-copy";
+@import "components/file-textarea";
 @import "components/more-info-icon";
 @import "components/resource-list-grid";

--- a/app/styles/components/_file-textarea.scss
+++ b/app/styles/components/_file-textarea.scss
@@ -1,0 +1,18 @@
+@keyframes dropTargetActive {
+  from {
+    background-color: rgba(102, 175, 233, 0.075);
+    border-color: #999;
+    box-shadow: none;
+  }
+  to {
+    background-color: #fff;
+    border-color: #66afe9;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  }
+}
+
+.drop-target-active {
+  textarea.form-control {
+    animation: 1.25s ease-in-out 0s infinite alternate dropTargetActive;
+  }
+}

--- a/app/templates/components/file-textarea.hbs
+++ b/app/templates/components/file-textarea.hbs
@@ -1,0 +1,6 @@
+{{textarea
+    class="form-control"
+    value=value
+    name=name
+    rows=rows
+    autofocus=autofocus}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-aptible-shared",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Shared assets for Aptible's Ember apps",
   "directories": {
     "doc": "doc",

--- a/tests/integration/components/file-textarea-test.js
+++ b/tests/integration/components/file-textarea-test.js
@@ -1,0 +1,82 @@
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('file-textarea', { integration: true });
+
+test('renders a textarea', function(assert) {
+  this.render(
+    hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}')
+  );
+  assert.equal(this.$('textarea').length, 1);
+});
+
+test('sets a class when drag events are triggered', function(assert) {
+  this.render(
+    hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}')
+  );
+  let $elem = this.$('textarea').parent();
+
+  $elem.trigger('dragenter');
+  assert.ok($elem.is('.drop-target-active'));
+  $elem.trigger('drageleave');
+  assert.ok($elem.not('.drop-target-active'));
+});
+
+test('unsets drop target class on drop', function(assert) {
+  let dropEvent = {
+    type: 'drop',
+    stopPropagation: function() {},
+    preventDefault: function(){},
+    dataTransfer: {
+      files: [{
+        lastModified: 1457470091000,
+        name: 'test.txt',
+        size: 1675,
+        type: ''
+      }]
+    }
+  };
+  this.render(hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}'));
+  let $elem = this.$('textarea').parent();
+
+  $elem.trigger('dragenter');
+  assert.ok($elem.is('.drop-target-active'));
+  $elem.trigger(dropEvent);
+  assert.ok($elem.not('.drop-target-active'));
+});
+
+test('appends file contents to the textarea', function(assert) {
+  let txt1 = 'I love deadlines. I like the whooshing sound they make as they\n';
+  let txt2 = 'fly by. -- Douglas Adams';
+  let dropEvent = {
+    type: 'drop',
+    stopPropagation: function() {},
+    preventDefault: function(){},
+    dataTransfer: {
+      files: [{
+        name: 'test1.txt',
+        result: txt1
+      }, {
+        name: 'test2.txt',
+        result: txt2
+      }]
+    }
+  };
+
+  // Overwrite the FileReader class for testing
+  window.FileReader = class {
+    constructor() { }
+    readAsText(file) {
+      if (file.hasOwnProperty('result')) {
+        this.onload({ type: 'load', target: file });
+      }
+    }
+  };
+
+  this.render(hbs('{{file-textarea value="" name="body" rows=10}}'));
+  let $elem = this.$('textarea').parent();
+  let $textarea = this.$('textarea');
+
+  $elem.trigger(dropEvent);
+  assert.equal($textarea.val(), txt1 + txt2);
+});


### PR DESCRIPTION
Takes two dashboard PRs and moves share-able bits here.
- Frame buster, aptible/dashboard.aptible.com#552
- Drag-n-drop .crt, bundled .crt, and .key files to create certificates, aptible/dashboard.aptible.com#543

Those both got a merge thumbs up, so I'll merge this on Travis' green light and then do another dashboard PR to set the cli version and implement these changes.
