### PR TITLE
Allow HTML for popovers

### DIFF
--- a/app/mixins/components/bootstrap-component-options.js
+++ b/app/mixins/components/bootstrap-component-options.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
   title: null,
   content: null,
+  html: null,
   placement: 'bottom',
   'bs-container': 'body',
 
@@ -15,6 +16,7 @@ export default Ember.Mixin.create({
       title: () => this.get('title'),
       content: () => this.get('content'),
       placement: () => this.get('placement'),
+      html: () => this.get('html')
     };
 
     if (this.get('bs-container')) {


### PR DESCRIPTION
I'm adding some "Learn More" link to popovers in SPD.  This requires being able to optionally specify the `html` param for bootstrap's `popover()`.

<img width="453" alt="screenshot 2016-03-21 15 47 55" src="https://cloud.githubusercontent.com/assets/884151/13936637/4a119476-ef7c-11e5-8cda-3ddaed760095.png">
