### PR TITLE
add created_at to attestations and validation error parsing

### DIFF
--- a/app/models/attestation.js
+++ b/app/models/attestation.js
@@ -1,11 +1,31 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+export const VALIDATION_ERROR_TEST = /#\//;
+export const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
+export const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+
 let Attestation = DS.Model.extend({
   handle: DS.attr('string'),
   organizationUrl: DS.attr('string'),
   schemaId: DS.attr('string'),
-  document: DS.attr({ defaultValue: {} })
+  document: DS.attr({ defaultValue: {} }),
+  createdAt: DS.attr('iso-8601-timestamp'),
+
+  validationErrors: Ember.computed('errors.[]', function() {
+    let validationErrors = [];
+    this.get('errors').forEach((error) => {
+      let message = error.message;
+      if (VALIDATION_ERROR_TEST.test(message)) {
+        let path = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
+                          .replace('/', '.');
+        let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
+                           .replace('did', 'does');
+        validationErrors.push({ path, error });
+      }
+    });
+    return validationErrors;
+  })
 });
 
 Attestation.reopenClass({

--- a/app/models/attestation.js
+++ b/app/models/attestation.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+let { decamelize, capitalize } = Ember.String;
+
 export const VALIDATION_ERROR_TEST = /#\//;
 export const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
 export const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
@@ -21,7 +23,11 @@ let Attestation = DS.Model.extend({
                           .replace('/', '.');
         let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
                            .replace('did', 'does');
-        validationErrors.push({ path, error });
+
+        let property = path.split('.').reverse()[0];
+        let propertyName = capitalize(decamelize(property).replace('_', ' '));
+
+        validationErrors.push({ path, error, propertyName });
       }
     });
     return validationErrors;

--- a/tests/unit/models/attestation-test.js
+++ b/tests/unit/models/attestation-test.js
@@ -29,6 +29,7 @@ test('it maps schema errors to `validationErrors` property', function(assert) {
 
   let expected = {
     path: 'alertNotifications.enabledNotifications',
+    propertyName: 'Enabled notifications',
     error: 'does not contain a minimum number of items 1'
   };
 

--- a/tests/unit/models/attestation-test.js
+++ b/tests/unit/models/attestation-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import { moduleForModel, test } from 'ember-qunit';
+import modelDeps from '../../support/common-model-dependencies';
+import { stubRequest } from 'ember-cli-fake-server';
+
+moduleForModel('attestation', 'model:attestation', {
+  needs: modelDeps
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  assert.ok(!!model);
+});
+
+
+test('it maps schema errors to `validationErrors` property', function(assert) {
+  let model = this.subject();
+  let done = assert.async();
+
+  stubRequest('post', '/attestations', function() {
+    assert.ok(true, 'calls with correct URL');
+
+    return this.error(422, {
+      code: 422,
+      error: 'internal_server_error',
+      message: "The property '#/alertNotifications/enabledNotifications' did not contain a minimum number of items 1"
+    });
+  });
+
+  let expected = {
+    path: 'alertNotifications.enabledNotifications',
+    error: 'does not contain a minimum number of items 1'
+  };
+
+  return Ember.run(() => {
+    model.save().catch(() => {
+      assert.deepEqual(model.get('validationErrors'), [expected]);
+    }).finally(done);
+  });
+
+});


### PR DESCRIPTION
This PR adds a convenient computed that parses JSON schema validation errors into a usable property path and error message.  This allows for contextual error handling on invalid fields:

<img width="938" alt="screenshot 2016-04-06 15 44 11" src="https://cloud.githubusercontent.com/assets/884151/14335226/7ce174fe-fc0e-11e5-9d6d-bbfc682196ba.png">
