### PR TITLE
Catch different class of schema validation errors

### DIFF
--- a/app/models/attestation.js
+++ b/app/models/attestation.js
@@ -3,9 +3,48 @@ import Ember from 'ember';
 
 let { decamelize, capitalize } = Ember.String;
 
-export const VALIDATION_ERROR_TEST = /#\//;
-export const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
-export const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+const INVALID_PROPERTY_TEST = /^The property '#\//;
+const MISSING_REQUIRED_PROPERTY_TEST = /did not contain a required property/;
+const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
+
+function humanize(property) {
+  return capitalize(decamelize(property).replace(/_/ig, ' '));
+}
+
+function getMissingPropertyError(message) {
+  // Example Error:
+  // "The property '#/separateOrganizationalUnits' did not contain a required
+  // property of 'implemented'"
+  "The property '#/separateOrganizationalUnits' did not contain a required property of 'implemented'"
+  const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+  const PATH_SUFFIX_MATCH = /.*did not contain a required property of '([^']+)'$/
+
+  let initialPath = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
+                          .replace('/', '.');
+  let pathSuffix = message.replace(PATH_SUFFIX_MATCH, '$1');
+  let path = `${initialPath}.${pathSuffix}`;
+  let error = 'is required';
+
+  let propertyName = `${humanize(pathSuffix)} ${humanize(initialPath)}`;
+
+  return { path, error, propertyName };
+}
+
+function getInvalidPropertyError(message) {
+  // Example Error:
+  // "The property '#/alertNotifications/enabledNotifications' did not contain
+  // a minimum number of items 1"
+  const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+
+  let path = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
+                          .replace('/', '.');
+  let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
+                     .replace('did', 'does');
+  let property = path.split('.').reverse()[0];
+  let propertyName = humanize(property);
+
+  return { path, error, propertyName };
+}
 
 let Attestation = DS.Model.extend({
   handle: DS.attr('string'),
@@ -17,17 +56,10 @@ let Attestation = DS.Model.extend({
   validationErrors: Ember.computed('errors.[]', function() {
     let validationErrors = [];
     this.get('errors').forEach((error) => {
-      let message = error.message;
-      if (VALIDATION_ERROR_TEST.test(message)) {
-        let path = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
-                          .replace('/', '.');
-        let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
-                           .replace('did', 'does');
-
-        let property = path.split('.').reverse()[0];
-        let propertyName = capitalize(decamelize(property).replace('_', ' '));
-
-        validationErrors.push({ path, error, propertyName });
+      if(MISSING_REQUIRED_PROPERTY_TEST.test(error.message)) {
+        validationErrors.push(getMissingPropertyError(error.message));
+      } else if(INVALID_PROPERTY_TEST.test(error.message)) {
+        validationErrors.push(getInvalidPropertyError(error.message));
       }
     });
     return validationErrors;

--- a/tests/unit/models/attestation-test.js
+++ b/tests/unit/models/attestation-test.js
@@ -38,5 +38,31 @@ test('it maps schema errors to `validationErrors` property', function(assert) {
       assert.deepEqual(model.get('validationErrors'), [expected]);
     }).finally(done);
   });
+});
 
+test('validation errors for required fields are mapped correctly', function(assert) {
+  let model = this.subject();
+  let done = assert.async();
+
+  stubRequest('post', '/attestations', function() {
+    assert.ok(true, 'calls with correct URL');
+
+    return this.error(422, {
+      code: 422,
+      error: 'internal_server_error',
+      message: "The property '#/separateOrganizationalUnits' did not contain a required property of 'implemented'"
+    });
+  });
+
+  let expected = {
+    path: 'separateOrganizationalUnits.implemented',
+    propertyName: 'Implemented Separate organizational units',
+    error: 'is required'
+  };
+
+  return Ember.run(() => {
+    model.save().catch(() => {
+      assert.deepEqual(model.get('validationErrors'), [expected]);
+    }).finally(done);
+  });
 });


### PR DESCRIPTION
The schema validation errors from ruby-json-schema leave much to be desired.  This PR adds another method for extracting a meaningful error message from ruby-json-schema validation errors.

For example, this PR will translate this error:

> The property '#/separateOrganizationalUnits' did not contain a required property of 'implemented'

Into this object:

``` javascript
{
    path: 'separateOrganizationalUnits.implemented',
    propertyName: 'Implemented Separate organizational units',
    error: 'is required'
};
```

This is useful because each field in SPD can now bind to errors that match their document path and actually render validation errors in context.
