### PR TITLE
Update Test Helpers

### DIFF
--- a/test-support/helpers/aptible-helpers.js
+++ b/test-support/helpers/aptible-helpers.js
@@ -24,7 +24,7 @@ Ember.Test.registerAsyncHelper('signIn', function(app, userData, roleData, token
     privileged: true,
     _links: {
       self: { href: `/roles/${roleData.id}` },
-      organization: { href: '/organizations/o1' }
+      organization: { href: '/organizations/1' }
     }
   };
 
@@ -95,7 +95,7 @@ Ember.Test.registerAsyncHelper('expectRedirectsWhenLoggedIn', function(app, url)
   signInAndVisit(url);
 
   andThen(function(){
-    equal(currentPath(), 'dashboard.stack.apps.index');
+    equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
   });
 });
 


### PR DESCRIPTION
Required updates for dashboard tests. Updates the default `orgId`s for test stubs as well as a new redirect route name that ensures the current user has read access on at least some platform resources before sending them to `stack.apps.index`.

It was a bit of a coin toss to pick either `o1` or `1` for the default `orgId`, but it ended up being a little less work for `1`, so that option won. 🏆

CC: @sandersonet 
