### PR TITLE
Add support for 2FA

### DIFF
--- a/app/application/torii-provider.js
+++ b/app/application/torii-provider.js
@@ -18,7 +18,9 @@ export default BaseProvider.extend({
       xhrFields: { withCredentials: true }
     }).catch(function(jqXHR){
       if (jqXHR.responseJSON) {
-        throw new Error(jqXHR.responseJSON.message);
+        let err = new Error(jqXHR.responseJSON.message);
+        err.authError = jqXHR.responseJSON.error;
+        throw err;
       } else if (jqXHR.responseText) {
         throw new Error(jqXHR.responseText);
       } else {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -9,7 +9,10 @@ export default DS.Model.extend({
   password: DS.attr('string'),
   verified: DS.attr('boolean'),
   createdAt: DS.attr('date'),
-  superuser : DS.attr('boolean'),
+  superuser: DS.attr('boolean'),
+  otpEnabled: DS.attr('boolean'),
+  otpUri: DS.attr('string'),
+  otpToken: DS.attr('string'),
 
   // used when changing a user's password. Set as an `attr` so that it
   // will be sent to the API
@@ -17,6 +20,9 @@ export default DS.Model.extend({
 
   // not persisted, used when changing a user's password
   passwordConfirmation: null,
+
+  // Used when enabling 2FA. Set as an `attr` so that it's sent to the API;
+  otpReset: DS.attr('boolean'),
 
   // relationships
   token: DS.belongsTo('token', { async: true, requireReload: true }),


### PR DESCRIPTION
Two changes:
- Add 2FA fields on User objects
- Add the error code when we fail to authenticate, which lets Dashboard
  show a 2FA prompt if authentication failed due to 2FA being enabled
  and no token being provided.

This is required for https://github.com/aptible/dashboard.aptible.com/pull/584 to work.
