### PR TITLE
Catch 404s on reload

### DIFF
--- a/app/mixins/models/provisionable.js
+++ b/app/mixins/models/provisionable.js
@@ -55,6 +55,13 @@ export const ProvisionableBaseMixin = Ember.Mixin.create({
       setTimeout(() => {
         run(this, '_recursiveReload');
       }, this._reloadRetryDelay);
+    }).catch((err) => {
+      if(err.message.indexOf('notFound') > -1) {
+        this.deleteRecord();
+        return;
+      }
+
+      throw err;
     });
   })),
 

--- a/app/models/operation.js
+++ b/app/models/operation.js
@@ -48,6 +48,12 @@ export default DS.Model.extend({
             return resolve(reloadUntilOperationStatusChanged(o, maximumTimeout, timeout * 2));
           }, timeout);
         });
+      }).catch((err) => {
+        // Catch error caused by the operation not existing if its associated resource
+        // has been removed in the backend.
+        if(err.status !== 404) {
+          throw err;
+        }
       });
     };
 


### PR DESCRIPTION
On provisionable models as well as operations, the reload can fail if
the model has been deleted on the backend. This commit catches this
and just stops the reloading of the model.

cc @sandersonet @gib 
