### PR TITLE
Indicate total member of a role

### DIFF
--- a/app/components/user-gravatars/component.js
+++ b/app/components/user-gravatars/component.js
@@ -6,5 +6,8 @@ export default Ember.Component.extend({
   truncatedUsers: Ember.computed('users.[]', 'count', function() {
     let count = this.get('count') || this.get('users.length');
     return Ember.A(this.get('users').slice(0, count));
+  }),
+  difference: Ember.computed('users.[]', 'count', function() {
+    return Math.max(this.get('users.length') - this.get('count'), 0);
   })
 });

--- a/app/templates/components/user-gravatars.hbs
+++ b/app/templates/components/user-gravatars.hbs
@@ -7,3 +7,6 @@
 {{else}}
   <li>{{placeholder}}</li>
 {{/each}}
+{{#if difference}}
+  <li class="user-gravatar-remainder">+ {{difference}} more</li>
+{{/if}}

--- a/tests/unit/components/user-gravatars-test.js
+++ b/tests/unit/components/user-gravatars-test.js
@@ -44,3 +44,41 @@ test('it truncates users when passed a count', function(assert) {
 
   assert.equal(component.get('truncatedUsers.length'), 2, 'count of 2 truncates to 2 users');
 });
+
+test('it displays the remainder when the number of users exceeds the count', function(assert) {
+  let users = Ember.A([
+    Ember.Object.create({ email: 'test@example.com'}),
+    Ember.Object.create({ email: 'test1@example.com'}),
+    Ember.Object.create({ email: 'test2@example.com'}),
+    Ember.Object.create({ email: 'test3@example.com'}),
+  ]);
+
+  this.subject({
+    users: users,
+    size: 24,
+    count: 2,
+    placeholder: '--'
+  });
+
+  this.render();
+
+  assert.equal($('.user-gravatar-remainder:contains("+ 2 more")').length, 1, 'displays there are 2 more users');
+});
+
+test('it does not show a remainder when the users are less than or equal to the a count', function(assert) {
+  let users = Ember.A([
+    Ember.Object.create({ email: 'test@example.com'}),
+    Ember.Object.create({ email: 'test1@example.com'})
+  ]);
+
+  this.subject({
+    users: users,
+    size: 24,
+    count: 2,
+    placeholder: '--'
+  });
+
+  this.render();
+
+  assert.equal($('.user-gravatar-remainder').length, 0, 'no remainder of users');
+});


### PR DESCRIPTION
A rendered role summary only includes 5 of the total members. This adds “+ n more” for roles with more than five total members.

<img width="333" alt="screen shot 2016-05-13 at 1 53 03 am" src="https://cloud.githubusercontent.com/assets/94830/15251563/4347660e-18e7-11e6-9611-f249339116d5.png">

Closes https://github.com/aptible/dashboard.aptible.com/issues/592 when a new release of ember shared is added to dashboard
