### PR TITLE
Add Announcements link, to open Intercom sidebar

### DIFF
--- a/app/templates/components/dashboard-dropdown-user-menu.hbs
+++ b/app/templates/components/dashboard-dropdown-user-menu.hbs
@@ -24,6 +24,10 @@
 
 <div>
   {{#dashboard-dropdown-item}}
+    <a href="javascript:Intercom('show');">Announcements</a>
+  {{/dashboard-dropdown-item}}
+
+  {{#dashboard-dropdown-item}}
     {{link-to 'Logout' 'logout'}}
   {{/dashboard-dropdown-item}}
 </div>


### PR DESCRIPTION
This is in the spirit of Leeroy, but please let me know whether there's a better, less aggressive approach. Also, "Announcements" versus "Product Announcements" versus something else?

The Intercom app for dashboard.aptible.com (production and staging) should be all set up to do what we want: 
- Provide a lightweight notification when there are new product announcements, and also provide customers with a way to view past announcements (from the nav bar)
- Disable replies (and don't show the floating Intercom chat button)
- Allow us to collect lightweight feedback ( 👍  or 👎 ; 😄 , 😐 , or 😦 )

To test this out, `npm link` this change locally, duplicate [this sample manual message](https://app.intercom.io/a/apps/npjjtw5f/messages/manual/29693625/show) on the dashboard.aptible-staging.com Intercom app, and select your own user as the audience. (For a real announcement, we'd select all users.) I've linked the dashboard.aptible-staging.com Intercom app to both the "frontend-staging" and "frontend-development" apps, so you should be able to test this in both local and staging environments.

@gib and @sandersonet: Do you think the Intercom sidebar styles are OK to use as is?

@krallin: Once this is merged and deployed, you can send an announcement to production users by creating a manual message just like the one I've linked to above, except in the production app. I am more than happy to walk through this process the first time, and we can document the procedure in more detail afterward.
