### PR TITLE
requires-read-access: Fix activating-item

### DIFF
--- a/app/components/activating-item/component.js
+++ b/app/components/activating-item/component.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import layout from '../../templates/components/activating-item';
 
+const ALLOWED_PREFIXES = ['', 'dashboard.', 'dashboard.requires-read-access.'];
+
 export default Ember.Component.extend({
   routingService: Ember.inject.service('routing'),
   layout: layout,
@@ -11,8 +13,11 @@ export default Ember.Component.extend({
   active: Ember.computed('routingService.currentPath', 'currentWhen', function() {
     let currentPath = this.get('routingService.currentPath');
     let currentWhen = this.get('currentWhen');
-    let offset = currentPath.indexOf(currentWhen);
-    // with our without dashboard prefix
-    return offset === 0 || (offset === 10 && currentPath.indexOf('dashboard') === 0);
+
+    return ALLOWED_PREFIXES.some((prefix) => {
+      // NOTE: Perhaps we could have babel give us startsWith?
+      let prefixedCurrentWhen = `${prefix}${currentWhen}`;
+      return currentPath.substring(0, prefixedCurrentWhen.length) === prefixedCurrentWhen;
+    });
   })
 });


### PR DESCRIPTION
activating-item needs to look at the new requires-read-access prefix. Otherwise, it's never going to be true on affected pages (right now if you look at Dashboard, it does not work).

cc @gib @sandersonet 
