### PR TITLE
Remove persistToken

### DIFF
--- a/app/utils/tokens.js
+++ b/app/utils/tokens.js
@@ -36,15 +36,3 @@ export function getPersistedToken() {
     }
   }).catch(rethrowJqXhrError);
 }
-
-export function persistToken(token) {
-  return ajax(config.authBaseUri + '/tokens/' + token.id + '?persist=true', {
-    type: 'GET',
-    headers: {
-      'Authorization': 'Bearer ' + token.get("accessToken")
-    },
-    xhrFields: {
-      withCredentials: true
-    }
-  }).catch(rethrowJqXhrError);
-}


### PR DESCRIPTION
Dammit, I forgot to include this in the PR. This function isn't actually used anywhere, and doesn't work in the Auth API anyway (I removed it because it's not used).

So, removing it.
