### PR TITLE
Use actor instead of user in analytics

### DIFF
--- a/app/application/torii-adapter.js
+++ b/app/application/torii-adapter.js
@@ -46,7 +46,7 @@ export default Ember.Object.extend({
         return session;
       });
     }).then((session) => {
-      this.identifyToAnalytics(session.currentUser);
+      this.identifyToAnalytics(session.currentActor || session.currentUser);
       return session;
     }).catch(function(e){
       clearSession();


### PR DESCRIPTION
When impersonating, we don't want to:
- Show notifications intended for the user to the actor.
- Record activity for the user.

cc @gib @sandersonet 
