### PR TITLE
Cleanup impersonation

### DIFF
--- a/app/application/torii-adapter.js
+++ b/app/application/torii-adapter.js
@@ -62,23 +62,27 @@ export default Ember.Object.extend({
     return this._authenticateWithPayload(tokenPayload);
   },
 
-  close(token) {
-    Ember.assert(
-      `A token must be passed: session.close('aptible', /*token*/);`,
-      !!token
-    );
-
+  close(options) {
+    options = options || {};
     let promise;
 
-    if (!!token.noDelete) {
+    if (!!options.noDelete) {
       promise = new Ember.RSVP.Promise((resolve, _) => resolve());
     } else {
-      promise = ajax(config.authBaseUri+`/tokens/${token.get('id')}`, {
+      const token = options.token;
+      Ember.assert(`A token must be passed: session.close('aptible', { token: /*token*/ });`, !!token);
+
+      const xhrFields = {};
+      if (!options.noClearCookies) {
+        xhrFields.withCredentials = true;
+      }
+
+      promise = ajax(`${config.authBaseUri}/tokens/${token.get('id')}`, {
         type: 'DELETE',
         headers: {
-          'Authorization': 'Bearer ' + getAccessToken()
+          'Authorization': 'Bearer ' + token.get("accessToken") || getAccessToken()
         },
-        xhrFields: { withCredentials: true }
+        xhrFields: xhrFields
       });
     }
 

--- a/tests/unit/torii-adapters/application-test.js
+++ b/tests/unit/torii-adapters/application-test.js
@@ -30,7 +30,7 @@ moduleFor('torii-adapter:application', 'Torii Adapter: Aptible', {
   }
 });
 
-test('#close destroys token, storage', function(assert){
+test('#close destroys token, storage by default', function(assert){
   assert.expect(4);
   const done = assert.async();
   var adapter = this.subject({
@@ -54,7 +54,7 @@ test('#close destroys token, storage', function(assert){
   });
 
   Ember.run(function(){
-    adapter.close(token).then(function(){
+    adapter.close({token: token}).then(function(){
       assert.ok(true, 'session is opened with an auth_token');
       assert.equal(removedKey, config.authTokenKey, 'removes token value');
       assert.ok(!getAccessToken(), 'unsets token on auth');


### PR DESCRIPTION
This adds some supporting change for an impersonation cleanup. Everything is in the commit messages, reproduced here for convenience:

**signIn helper: don't access session directly** (I guess this one might be a little controversial)

In practice, this function has been a recurring problem for me; since it
only accepts a few very specific parameters that it loads into the user,
token, and session, it's never quite up to date with the rest of the
code, and tests end up failing because the stub isn't stubbing things
properly.

Getting rid of the stub entirely, and relying on `/current_token`
instead seems like a better option.

**Expose a noClearCookies flag when closing session**

This also refactors the session argument to be an options hash rather
than just a token, since we're starting to add multiple arguments.

The use case for the noClearCookies flag is to allow impersonation to
create a user token, persist it to cookies, destroy the admin token
(without touching cookies), and then reload the UI to log back in as the
user.
