### PR TITLE
Update attestation path to be child of organization profile

### DIFF
--- a/app/adapters/attestation.js
+++ b/app/adapters/attestation.js
@@ -1,6 +1,28 @@
 import GridironAdapter from './gridiron';
+import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default GridironAdapter.extend({
+  _buildURL: buildURLWithPrefixMap({
+      'organization_profiles': {
+        property: 'organizationProfile.id', only: ['create', 'findquery']
+      }
+  }),
+
+  buildURL(type, id, snapshot, requestType, params = {}) {
+    if(params.organizationProfile) {
+      // When loading current attestations by handle, we need to specify an
+      // organization profile ID.
+      let temp = this.store.createRecord('attestation', {
+        organizationProfile: params.organizationProfile
+      });
+
+      snapshot = { record: temp };
+      delete params.organizationProfile;
+    }
+
+    return this._buildURL.call(this, type, id, snapshot, requestType, params);
+  },
+
   updateRecord() {
     // Attestations are append only.  Overloading updateRecord with createRecord
     // forces attestation updates to POST rather than PUT

--- a/app/models/attestation.js
+++ b/app/models/attestation.js
@@ -56,6 +56,7 @@ let Attestation = DS.Model.extend({
   schemaId: DS.attr('string'),
   document: DS.attr({ defaultValue: {} }),
   createdAt: DS.attr('iso-8601-timestamp'),
+  organizationProfile: DS.belongsTo('organizationProfile', {async: true}),
 
   setUser(user) {
     Ember.assert('user must be a User model', user instanceof User);
@@ -82,13 +83,14 @@ let Attestation = DS.Model.extend({
 
 Attestation.reopenClass({
   findOrCreate(params, store) {
-    if (!(params.handle && params.organizationUrl)) {
-      throw new Error('You must provide both a `handle` and an `organizationUrl` to `Attestation.findOrCreate`');
+
+    if (!(params.handle && params.organizationProfile)) {
+      throw new Error('You must provide both a `handle` and an `organizationProfile` to `Attestation.findOrCreate`');
     }
 
-    let handle = params.handle;
-    let organization = params.organizationUrl;
-    let findParams = { current: true, handle, organization };
+    let { handle, organizationProfile } = params;
+
+    let findParams = { current: true, handle, organizationProfile };
 
     return new Ember.RSVP.Promise((resolve) => {
       store.find('attestation', findParams)
@@ -101,7 +103,9 @@ Attestation.reopenClass({
         })
 
         // In case of error, just create new attestation
-        .catch(() => { resolve( store.createRecord('attestation', params)); });
+        .catch(() => {
+          resolve( store.createRecord('attestation', params));
+        });
     });
   }
 });

--- a/app/models/organization-profile.js
+++ b/app/models/organization-profile.js
@@ -10,6 +10,7 @@ let OrganizationProfile = DS.Model.extend({
   aboutOrganization: DS.attr('string'),
   aboutProduct: DS.attr('string'),
   organization: DS.attr('string'),
+  attestations: DS.hasMany('attestation', {async: true}),
 
   indexOfCurrentStep: Ember.computed('currentStep', function() {
     return this.indexOfStep(this.get('currentStep'));

--- a/app/utils/build-url-with-prefix-map.js
+++ b/app/utils/build-url-with-prefix-map.js
@@ -59,7 +59,7 @@ function checkConditions(requestType, conditions){
  */
 export default function buildURLWithPrefixMap(prefixPropertyMapping){
   // From ember-data's buildURL: https://github.com/emberjs/data/blob/ff35ee78bfac058afb7a715a5dfc5760218cc05c/packages/ember-data/lib/adapters/build-url-mixin.js#L51
-  return function buildURL(type, id, snapshot, requestType) {
+  return function buildURL(type, id, snapshot, requestType, params) {
     let url = [],
         host = Ember.get(this, 'host'),
         prefix = this.urlPrefix();
@@ -91,7 +91,14 @@ export default function buildURLWithPrefixMap(prefixPropertyMapping){
     if (prefix) { url.unshift(prefix); }
 
     url = url.join('/');
-    if (!host && url) { url = '/' + url; }
+    if (!host && url) {
+      url = '/' + url;
+    }
+
+    // If a params hash is passed, serialize into a query string.
+    if(params) {
+      url = url + '?' + Ember.$.param(params);
+    }
 
     return url;
   };

--- a/tests/unit/models/attestation-test.js
+++ b/tests/unit/models/attestation-test.js
@@ -4,7 +4,7 @@ import modelDeps from '../../support/common-model-dependencies';
 import { stubRequest } from 'ember-cli-fake-server';
 
 moduleForModel('attestation', 'model:attestation', {
-  needs: modelDeps
+  needs: modelDeps.concat(['model:organization-profile'])
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
This PR updates attestations to use the new routes included in: https://github.com/aptible/gridiron.aptible.com/pull/85
