### PR TITLE
New risk assessment models and serializer

### DIFF
--- a/app/models/mitigation.js
+++ b/app/models/mitigation.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  efficacy: DS.attr('number'),
+  vulnerability: DS.belongsTo('vulnerability', { embedded: true }),
+  securityControl: DS.belongsTo('securityControl', { embedded: true })
+});

--- a/app/models/predisposing-condition.js
+++ b/app/models/predisposing-condition.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  handle: DS.attr('string'),
+  title: DS.attr('string'),
+  description: DS.attr('string'),
+  pervasiveness: DS.attr('number')
+});

--- a/app/models/risk-assessment.js
+++ b/app/models/risk-assessment.js
@@ -6,5 +6,10 @@ export default DS.Model.extend({
   approvingAuthorityUserName: DS.attr('string'),
   approvingAuthorityUserEmail:DS.attr('string'),
   approvingAuthorityUrl: DS.attr('string'),
-  graph: DS.attr()
+  vulnerabilities: DS.hasMany('vulnerability', {embedded: true}),
+  threatEvents: DS.hasMany('threatEvent', {embedded: true}),
+  predisposingConditions: DS.hasMany('predisposingCondition', {embedded: true}),
+  threatSources: DS.hasMany('threatSource', {embedded: true}),
+  securityControls: DS.hasMany('securityControl', {embedded: true}),
+  mitigations: DS.hasMany('mitigation', {embedded: true})
 });

--- a/app/models/security-control.js
+++ b/app/models/security-control.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  handle: DS.attr('string'),
+  title: DS.attr('string'),
+  description: DS.attr('string'),
+  efficacy: DS.attr('number'),
+  implemented: DS.attr('boolean'),
+  planned: Ember.computed.bool('plannedMilestone'),
+  plannedMilestone: DS.attr('string'),
+  vulnerabilities: DS.hasMany('vulnerability', { embedded: true })
+});

--- a/app/models/threat-event.js
+++ b/app/models/threat-event.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  handle: DS.attr('string'),
+  title: DS.attr('string'),
+  description: DS.attr('string'),
+  relevance: DS.attr('number'),
+  baseImpact: DS.attr('number'),
+  likelihoodOfOccurence: DS.attr('number'),
+  adversarial: DS.attr('boolean'),
+  vulnerabilities: DS.hasMany('vulnerability', { async: false }),
+  threatSources: DS.hasMany('threatSource', { async: false }),
+  predisposingConditions: DS.hasMany('predisposingCondition', { async: false })
+});

--- a/app/models/threat-source.js
+++ b/app/models/threat-source.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  handle: DS.attr('string'),
+  title: DS.attr('string'),
+  description: DS.attr('string'),
+  capability: DS.attr('number'),
+  intent: DS.attr('number'),
+  targeting: DS.attr('number'),
+  rangeOfEffects: DS.attr('number'),
+  adversarial: DS.attr('boolean')
+});

--- a/app/models/vulnerability.js
+++ b/app/models/vulnerability.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  riskAssessment: DS.belongsTo('riskAssessment'),
+  handle: DS.attr('string'),
+  title: DS.attr('string'),
+  description: DS.attr('string'),
+  severity: DS.attr('number'),
+  securityControls: DS.hasMany('securityControl', { embedded: true })
+});

--- a/app/serializers/attestation.js
+++ b/app/serializers/attestation.js
@@ -3,15 +3,5 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   attrs: {
     id: { serialize: false }
-  },
-
-  serialize(snapshot, options) {
-    // REVIEW: Gridiron controllers consistently look for `organization` param to
-    // be a URL to the org.  The model attribute, however, is stored as
-    // `organization_url`.  This custom serializer fixes that.
-
-    let json = this._super(snapshot, options);
-    json.organization = snapshot.get('organizationUrl');
-    return json;
   }
 });

--- a/app/serializers/risk-assessment.js
+++ b/app/serializers/risk-assessment.js
@@ -1,0 +1,110 @@
+import ApplicationSerializer from './application';
+
+export const RISK_ASSESSMENT_COMPONENTS = ['mitigations', 'threat_sources',
+                                          'security_controls', 'vulnerabilities',
+                                          'predisposing_conditions', 'threat_events'];
+
+// This serializer does 2 important things to make Ember Data relationships work
+// with risk assessment components.  Components will always be embedded--there
+// should never be an AJAX request to load any component of a risk assessment.
+
+// Job 1:
+// The Risk Assessment's ID is used to prefix all model component's own IDs.
+// This prevents risk assessment components from colliding with components
+// of other risk assessments once loaded into the Ember Data store.  Without
+// the prefix, we could possibly load common component IDs multiple times:
+// e.g. `craft_spear_phishing` likely exists as a threat event in multiple
+// risk assessments--these threat events would become one if we didn't otherwise
+// differentiate their IDs.
+
+// Job 2:
+// All components are updated to included updated references to related
+// components.  This includes:
+//  * Adding the `risk_assessment_id` field to all components
+//  * Flattening mitigations and instead adding the relationships between
+//  vulnerabilities and security controls to fields directly on those components
+//  * Updating all relationship keys to include the risk assessment id as a prefix
+
+export default ApplicationSerializer.extend({
+  extractArray(store, primaryType, rawPayload) {
+    rawPayload._embedded.risk_assessments.map((riskAssessment) => {
+      return this._extractRiskAssessment(riskAssessment);
+    });
+
+    return this._super(store, primaryType, rawPayload);
+  },
+
+  extractSingle(store, primaryType, rawPayload, recordId) {
+    rawPayload = _extractRiskAssessment(rawPayload);
+    return this._super(store, primaryType, rawPayload, recordId);
+  },
+
+  _extractRiskAssessment(riskAssessment) {
+    riskAssessment = this._addRiskAssesmentIdToEmbeddeds(riskAssessment);
+    riskAssessment = this._updateRelationshipKeysWithPrefix(riskAssessment);
+    riskAssessment = this._flattenMitigations(riskAssessment);
+
+    return riskAssessment;
+  },
+
+  _addRiskAssesmentIdToEmbeddeds(riskAssessment) {
+  // Step 1:
+    // For each resource, add a reference to `risk_assessment_id` and update
+    // the resources ID to be prefixed with the risk assessment ID.
+    RISK_ASSESSMENT_COMPONENTS.forEach((type) => {
+      riskAssessment._embedded[type].map((typeInstance) => {
+        typeInstance.risk_assessment_id = riskAssessment.id;
+        typeInstance.id = `${riskAssessment.id}_${typeInstance.id}`;
+        return typeInstance;
+      });
+    });
+
+    return riskAssessment;
+  },
+
+  _updateRelationshipKeysWithPrefix(riskAssessment) {
+    // Step 2:
+    // For each threat event, updated hasMany keys to include the risk assessment
+    // ID as a prefix for each key.
+    riskAssessment._embedded.threat_events.map((threatEvent) => {
+      ['vulnerabilities', 'threat_sources', 'predisposing_conditions'].forEach((relationship) => {
+        threatEvent[relationship] = threatEvent[relationship].map((key) => {
+          return `${riskAssessment.id}_${key}`
+        });
+      })
+      return threatEvent;
+    });
+
+    // Update vulnerability and security control keys on mitigations
+    riskAssessment._embedded.mitigations.map((mitigation) => {
+      mitigation.vulnerability = `${riskAssessment.id}_${mitigation.vulnerability}`;
+      mitigation.security_control = `${riskAssessment.id}_${mitigation.security_control}`;
+      return mitigation;
+    });
+
+    return riskAssessment;
+  },
+
+  _flattenMitigations(riskAssessment) {
+    // Step 3:
+    // Security controls and vulnerabilitis are many-to-many through mitigations
+    // loop over mitigations and set references to relationships directly on
+    // each vuln and sc.
+    riskAssessment._embedded.mitigations.forEach((mitigation) => {
+      let vulnerability = riskAssessment._embedded.vulnerabilities.findBy('id', mitigation.vulnerability);
+      let sc = riskAssessment._embedded.security_controls.findBy('id', mitigation.security_control);
+
+      if(vulnerability) {
+        vulnerability.security_controls = vulnerability.security_controls || [];
+        vulnerability.security_controls.push(mitigation.security_control);
+      }
+
+      if(sc) {
+        sc.vulnerabilities = sc.vulnerabilities || [];
+        sc.vulnerabilities.push(mitigation.vulnerability);
+      }
+    });
+
+    return riskAssessment;
+  }
+});


### PR DESCRIPTION
This PR adds basic model definitions for risk assessment components.  
Combining this PR with https://github.com/aptible/gridiron.aptible.com/pull/89 allows the entire risk graph to be cleanly extracted into the ember data store.  e.g. `riskAssessment.get('threatEvents.firstObject.vulnerabilities')` is now possible

Once we have a bit more definition on the interaction between components, it will be easy to add computed properties to each of these components.

---

cc @gib 
