### PR TITLE
bs-XXXX: `options.html` should not be a function

### DIFF
--- a/app/components/bs-popover/component.js
+++ b/app/components/bs-popover/component.js
@@ -6,6 +6,7 @@
  *   * content: The text to be displayed in the popover body
  * Optional params:
  *   * placement: 'left','right','top','bottom' (default: 'bottom')
+ *   * bs-html: Whether HTML should be allowed. Default: false
  *   * bs-trigger: The triggering event ('click', 'focus', etc.). Default: none
  *   * bs-container: The container to use for the tooltip (e.g., 'body'). Default: none
  *

--- a/app/components/bs-tooltip/component.js
+++ b/app/components/bs-tooltip/component.js
@@ -5,6 +5,7 @@
  *   * title: The text to be displayed in the tooltip
  * Optional params:
  *   * placement: 'left','right','top','bottom' (default: 'bottom')
+ *   * bs-html: Whether HTML should be allowed. Default: false
  *   * bs-trigger: The triggering event ('click', 'focus', etc.). Default: none
  *   * bs-container: The container to use for the tooltip (e.g., 'body'). Default: none
  *

--- a/app/components/more-info-icon/component.js
+++ b/app/components/more-info-icon/component.js
@@ -3,5 +3,6 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'span',
   placement: 'bottom',
+  'bs-html': false,
   classNames: ['more-info-icon']
 });

--- a/app/mixins/components/bootstrap-component-options.js
+++ b/app/mixins/components/bootstrap-component-options.js
@@ -3,21 +3,27 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
   title: null,
   content: null,
-  html: null,
   placement: 'bottom',
   'bs-container': 'body',
 
   // Other possible options:
   //  * bs-trigger
   //  * bs-container
+  //  * bs-html
 
   getBootstrapOptions: function(){
+    // These will return functions, which is fine, because bootstrap
+    // explicitly accepts callables for those attributes.
     let options = {
       title: () => this.get('title'),
       content: () => this.get('content'),
-      placement: () => this.get('placement'),
-      html: () => this.get('html')
+      placement: () => this.get('placement')
     };
+
+    // NOTE: Bootstrap does not accept a callable for html, so we need to make
+    // sure this isn't accidentally set to a function, which might
+    // (unintentionally) evaluate to true!
+    options.html = (this.get('bs-html') === true);
 
     if (this.get('bs-container')) {
       options.container = this.get('bs-container');

--- a/app/templates/components/more-info-icon.hbs
+++ b/app/templates/components/more-info-icon.hbs
@@ -1,3 +1,3 @@
-{{#bs-popover title=title content=body bs-container='body' placement=placement bs-trigger='hover'}}
+{{#bs-popover title=title content=body bs-container='body' placement=placement bs-html=bs-html bs-trigger='hover'}}
   <i class="fa fa-question-circle"></i>
 {{/bs-popover}}


### PR DESCRIPTION
Bootstrap explicitly accepts functions for the `title`, `content` and
`placement` attributes. However, it most notably does not accept a
function for the `html` attribute, which controls whether the input
provided to e.g. `tooltip()` or `popover()` should be output as HTML.

This updates bootstrap-component-options to actually set a boolean. It
also exposes the option in `bs-tooltip`, `bs-popover`, and
`more-info-icon`.

---

cc @sandersonet @gib 
