### PR TITLE
Supporting changes for token revokation

### DIFF
--- a/app/application/torii-adapter.js
+++ b/app/application/torii-adapter.js
@@ -19,8 +19,9 @@ function pushTokenToStore(tokenPayload, store) {
     scope: tokenPayload.scope,
     rawPayload: JSON.stringify(tokenPayload),
     links: {
+      self: tokenPayload._links.self.href,
       user: tokenPayload._links.user.href,
-      actor: tokenPayload._links.actor && tokenPayload._links.actor.href
+      actor: tokenPayload._links.actor && tokenPayload._links.actor.href,
     }
   });
 }

--- a/app/templates/components/dashboard-dropdown-user-menu.hbs
+++ b/app/templates/components/dashboard-dropdown-user-menu.hbs
@@ -28,6 +28,6 @@
   {{/dashboard-dropdown-item}}
 
   {{#dashboard-dropdown-item}}
-    {{link-to 'Logout' 'logout'}}
+    {{link-to 'Logout' 'settings.logout'}}
   {{/dashboard-dropdown-item}}
 </div>

--- a/app/utils/tokens.js
+++ b/app/utils/tokens.js
@@ -1,5 +1,6 @@
 import ajax from "../utils/ajax";
 import config from "../config/environment";
+import { getAccessToken } from '../adapters/application';
 
 function rethrowJqXhrError(jqXHR) {
   // TODO: Use this everywhere.
@@ -33,6 +34,20 @@ export function getPersistedToken() {
     type: 'GET',
     xhrFields: {
       withCredentials: true
+    }
+  }).catch(rethrowJqXhrError);
+}
+
+export function revokeAllAccessibleTokens(options) {
+  options = options || {};
+
+  return ajax(config.authBaseUri + '/tokens/revoke_all_accessible', {
+    type: 'POST',
+    data: {
+      except_tokens: options.exceptTokenHrefs
+    },
+    headers: {
+      'Authorization': `Bearer ${getAccessToken()}`
     }
   }).catch(rethrowJqXhrError);
 }

--- a/test-support/helpers/aptible-helpers.js
+++ b/test-support/helpers/aptible-helpers.js
@@ -47,6 +47,7 @@ Ember.Test.registerHelper('createStubToken', function(app, tokenData, stubUser) 
     scope: 'manage',
     type: 'token',
     _links: {
+      self: { href: `/tokens/${tokenData.id}` },
       user: { href: stubUser._links.self.href }
     }
   };

--- a/test-support/helpers/shared-tests.js
+++ b/test-support/helpers/shared-tests.js
@@ -13,6 +13,7 @@ export function signupInputsTest(url){
 }
 
 export function doSignupSteps(url, userInput, options={}){
+  // TODO: Use createStubUser, createStubToken
   let defaultInput = {
     name: 'bob', email: 'bob@gmail.com', password: 'abcDEF012!@#'
   };

--- a/test-support/helpers/successful-token-response.js
+++ b/test-support/helpers/successful-token-response.js
@@ -1,4 +1,5 @@
 export default function successfulTokenResponse(server, userUrl) {
+  // TODO: Deprecate usage, use createStubToken instead.
   return server.success({
     id: 'my-id',
     access_token: 'my-token',
@@ -9,6 +10,9 @@ export default function successfulTokenResponse(server, userUrl) {
     _links: {
       user: {
         href: userUrl
+      },
+      self: {
+        href: '/tokens/my-id'
       }
     }
   });

--- a/tests/unit/torii-adapters/application-test.js
+++ b/tests/unit/torii-adapters/application-test.js
@@ -80,6 +80,7 @@ test('#open stores payload, set currentUser', function(assert){
   var userId = 'some-user-id';
   var userUrl = '/some-user-url';
   var userEmail = 'some@email.com';
+  var tokenUrl = '/some-token-url';
 
   stubRequest('get', userUrl, function(){
     return this.success({
@@ -96,6 +97,9 @@ test('#open stores payload, set currentUser', function(assert){
     _links: {
       user: {
         href: userUrl
+      },
+      self: {
+        href: tokenUrl
       }
     }
   };
@@ -128,6 +132,7 @@ test('#fetch fetches current_token, stores payload, set currentUser', function(a
   var userUrl = '/some-user-url';
   var currentTokenUrl = '/current_token';
   var userEmail = 'some@email.com';
+  var tokenUrl = '/some-token-url';
 
   stubRequest('get', currentTokenUrl, function(){
     return this.success({
@@ -136,6 +141,9 @@ test('#fetch fetches current_token, stores payload, set currentUser', function(a
       _links: {
         user: {
           href: userUrl
+        },
+        self: {
+          href: tokenUrl
         }
       }
     });
@@ -185,6 +193,7 @@ test('#fetch fetches current_token, stores payload, set currentUser, currentActo
   var actorUrl = '/some-actor-id';
   var actorEmail = 'some@actor.com';
   var currentTokenUrl = '/current_token';
+  var tokenUrl = '/some-token-url';
 
   stubRequest('get', currentTokenUrl, function(){
     return this.success({
@@ -196,6 +205,9 @@ test('#fetch fetches current_token, stores payload, set currentUser, currentActo
         },
         actor: {
           href: actorUrl
+        },
+        self: {
+          href: tokenUrl
         }
       }
     });


### PR DESCRIPTION
This adds supporting changes for token revokation, which mainly boil
down to:
- Properly persisting the token's HREF when logging in so that we can
  preserve it later on (and supporting that in mocks).
- Adding a `revokeAllAccessibleTokens` helper method that calls the
  corresponding API.

---

cc @fancyremarker @sandersonet @gib 
