### PR TITLE
Store `findStacksFor` should return a `DS.PromiseArray`

### DIFF
--- a/app/application/store.js
+++ b/app/application/store.js
@@ -4,11 +4,13 @@ export default DS.Store.extend({
 
   findStacksFor(organization) {
     var organizationUrl = organization.get('data.links.self');
-    return this.find('stack').then((stacks) => {
+    let promise = this.find('stack').then((stacks) => {
       return this.filter('stack', function(stack) {
         return stack.get('data.links.organization') === organizationUrl;
       });
     });
+
+    return DS.PromiseArray.create({ promise });
   },
 
   recordWasInvalid: function(internalModel, errors) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-aptible-shared",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "description": "Shared assets for Aptible's Ember apps",
   "directories": {
     "doc": "doc",

--- a/tests/unit/stores/application_test.js
+++ b/tests/unit/stores/application_test.js
@@ -50,7 +50,9 @@ test('#findStacksBy', function(assert) {
   });
 
   Ember.run(() => {
-    service.findStacksFor(organization).then(function(stacks){
+    let returnVal = service.findStacksFor(organization);
+    assert.ok(returnVal instanceof DS.PromiseArray, 'returns a PromisArray');
+    returnVal.then(function(stacks){
       assert.ok(true, 'completed query');
       assert.equal(stacks.get('length'), 1, 'has a single stack');
       assert.equal(stacks.get('firstObject.handle'), 'valid',


### PR DESCRIPTION
Was returning a `DS.Promise` which would not allow an Ember promise proxy to bind and resolve correctly.

Thanks @sandersonet for identifying and writing the fix here!
