### PR TITLE
Renaming requires-read-acces route

### DIFF
--- a/app/components/activating-item/component.js
+++ b/app/components/activating-item/component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../../templates/components/activating-item';
 
-const ALLOWED_PREFIXES = ['', 'dashboard.', 'dashboard.requires-read-access.'];
+const ALLOWED_PREFIXES = ['', 'dashboard.', 'dashboard.catch-redirects.'];
 
 export default Ember.Component.extend({
   routingService: Ember.inject.service('routing'),

--- a/test-support/helpers/aptible-helpers.js
+++ b/test-support/helpers/aptible-helpers.js
@@ -100,7 +100,7 @@ Ember.Test.registerAsyncHelper('expectRedirectsWhenLoggedIn', function(app, url)
   signInAndVisit(url);
 
   andThen(function(){
-    equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 


### PR DESCRIPTION
This PR updates the name of the `requires-read-access` to something more generic.  
