### PR TITLE
Refactor validation feedback component

### DIFF
--- a/app/components/validation-feedback/component.js
+++ b/app/components/validation-feedback/component.js
@@ -3,19 +3,32 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'span',
   classNames: ['input-group-addon'],
-
   /** @type {Boolean} Whether errors will show even if no value */
   hasSubmitted: false,
+  isSaving: false,
+  value: false,
 
-  shouldShowFeedback: Ember.computed.or("value", "hasSubmitted"),
+  // Converting model state into easy computed properties
+  hasValue: Ember.computed.bool('value'),
+  hasError: Ember.computed.bool('errorText'),
+  noError: Ember.computed.not('showError'),
+  notSaving: Ember.computed.not('isSaving'),
+  canValidate: Ember.computed.or('hasValue', 'hasSubmitted'),
 
-  errorText: Ember.computed("error.[]", "fieldName", function() {
-    var error = this.get("error");
-    var fieldName = this.get('fieldName');
+  // Computed used to determine visibility of different indicators using above
+  // computed properties
+  showSuccess: Ember.computed.and('notSaving', 'canValidate', 'noError'),
+  showError: Ember.computed.and('notSaving', 'canValidate', 'hasError'),
+  showSomething: Ember.computed.or('showSuccess', 'showError'),
+  showNothing: Ember.computed.not('showSomething'),
+
+  errorText: Ember.computed('error.[]', 'fieldName', function() {
+    let error = this.get('error');
+    let fieldName = this.get('fieldName');
 
     // If multiple errors, join errors with space and comma
     if(Array.isArray(error) && error.join) {
-      error = error.join(", ");
+      error = error.join(', ');
     }
 
     if(fieldName && error) {

--- a/app/styles/_input-validation.scss
+++ b/app/styles/_input-validation.scss
@@ -15,7 +15,7 @@
     position: absolute;
     right: 20px;
     top: 13px;
-    z-index: 2;
+    z-index: 4;
     border: 0;
     box-shadow: none;
     padding: 0;

--- a/app/templates/components/validation-feedback.hbs
+++ b/app/templates/components/validation-feedback.hbs
@@ -2,15 +2,17 @@
   <i class="fa fa-spin fa-spinner"></i>
 {{else}}
 
-  {{#if shouldShowFeedback}}
-    {{#if errorText}}
-      {{#bs-tooltip placement="right" title=errorText bs-trigger="immediate" bs-container=false}}
-        <i class="fa fa-times-circle"></i>
-      {{/bs-tooltip}}
-    {{else}}
-      <i class="fa fa-check-circle"></i>
-    {{/if}}
-  {{else}}
+  {{#if showError}}
+    {{#bs-tooltip placement="right" title=errorText bs-trigger="immediate" bs-container=false}}
+      <i class="fa fa-times-circle"></i>
+    {{/bs-tooltip}}
+  {{/if}}
+
+  {{#if showSuccess}}
+    <i class="fa fa-check-circle"></i>
+  {{/if}}
+
+  {{#if showNothing}}
     <i class="fa visibility-hidden"></i>
   {{/if}}
 


### PR DESCRIPTION
This PR addresses two minor, yet annoying bugs:

1) Somehow the z-index of the validation-feedback component is below that of the input itself, hiding the icon and part of the errorText hover.

2) Once a model is saved successfully, a superfluous validation is triggered.  This PR fixes that by honoring an 'isSaving' flag.  This is an ugly hack, but I can't think of a better way to prevent the extra validation when model attrs change after a save. 
