### PR TITLE
Catch 404s on reload

### DIFF
--- a/app/mixins/models/provisionable.js
+++ b/app/mixins/models/provisionable.js
@@ -56,7 +56,13 @@ export const ProvisionableBaseMixin = Ember.Mixin.create({
         run(this, '_recursiveReload');
       }, this._reloadRetryDelay);
     }).catch((err) => {
-      if (err.message && err.message.indexOf('notFound') > -1) {
+      // Believe it or not, this console.log has to currently be here . This is a textbook
+      // definition of a heisenbug. After adding the err.status check, if I had not added a
+      // console.log or a window.alert before this check, the model would immediately remove
+      // itself from the UI. If something wrong occurs, then the model reappears. Until someone
+      // figures out why that is, the console.log stays.
+      console.log(err);
+      if (404 === err.status || err.message && err.message.indexOf('notFound') > -1) {
         this.deleteRecord();
         return;
       }


### PR DESCRIPTION
This adds another check on top of #117 - this checks explicitly for
err.status == 404, otherwise log drains would not be removed after
deprovisioning them.

There's a minor WTF in this, which I don't really understand. There's
a heisenbug of sorts - now, unless there's a console.log or a
window.alert before the status check, the model will otherwise
immediately remove itself from the UI without regarding the status
that gets returned from the API.

@sandersonet @gib 
