### PR TITLE
Check for currentState before reloading

### DIFF
--- a/app/mixins/models/provisionable.js
+++ b/app/mixins/models/provisionable.js
@@ -42,7 +42,10 @@ export const ProvisionableBaseMixin = Ember.Mixin.create({
     } = this.getProperties('status', 'reloadWhileProvisioning', 'isDestroying', 'isDestroyed');
     let inReloadStatus = ReloadStatuses.indexOf(status) > -1;
 
-    return SHOULD_RELOAD && reloadWhileProvisioning && inReloadStatus && !isDestroyed && !isDestroying;
+    let currentState = this.get('currentState.stateName');
+    let inLoadedState = currentState !== 'root.empty' && currentState !== 'root.deleted.uncommitted';
+
+    return SHOULD_RELOAD && inLoadedState && reloadWhileProvisioning && inReloadStatus && !isDestroyed && !isDestroying;
   },
 
   // we should refactor this away from using observers once
@@ -56,7 +59,7 @@ export const ProvisionableBaseMixin = Ember.Mixin.create({
         run(this, '_recursiveReload');
       }, this._reloadRetryDelay);
     }).catch((err) => {
-      // Believe it or not, this console.log has to currently be here . This is a textbook
+      // Believe it or not, this console.log has to currently be here. This is a textbook
       // definition of a heisenbug. After adding the err.status check, if I had not added a
       // console.log or a window.alert before this check, the model would immediately remove
       // itself from the UI. If something wrong occurs, then the model reappears. Until someone

--- a/app/models/log-drain.js
+++ b/app/models/log-drain.js
@@ -28,7 +28,9 @@ export default DS.Model.extend(ProvisionableMixin, {
       isDestroyed
     } = this.getProperties('status', 'reloadWhileProvisioning', 'isDestroying', 'isDestroyed');
     let inReloadStatus = ReloadStatuses.indexOf(status) > -1;
-    let inLoadedState = this.get('currentState.stateName') !== 'root.empty';
+
+    let currentState = this.get('currentState.stateName');
+    let inLoadedState = currentState !== 'root.empty' && currentState !== 'root.deleted.uncommitted';
 
     return SHOULD_RELOAD && inLoadedState && reloadWhileProvisioning && inReloadStatus && !isDestroyed && !isDestroying;
   },


### PR DESCRIPTION
This builds upon #154. During a deprovisioning, the model will
periodically poll itself to see if it has been deleted from the api,
where it will then remove itself from the local model storage.

This checks the currentState of the model to ensure that it doesn't
reload if it is in either state == 'root.empty' or in state
'root.deleted.uncommitted'.

cc @sandersonet 
