### PR TITLE
abstract ruby json schema error handling into separate module

### DIFF
--- a/app/models/attestation.js
+++ b/app/models/attestation.js
@@ -1,51 +1,7 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 import User from './user';
-
-let { decamelize, capitalize } = Ember.String;
-
-const INVALID_PROPERTY_TEST = /^The property '#\//;
-const MISSING_REQUIRED_PROPERTY_TEST = /did not contain a required property/;
-const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
-
-function humanize(property) {
-  return capitalize(decamelize(property).replace(/_/ig, ' '));
-}
-
-function getMissingPropertyError(message) {
-  // Example Error:
-  // "The property '#/separateOrganizationalUnits' did not contain a required
-  // property of 'implemented'"
-  "The property '#/separateOrganizationalUnits' did not contain a required property of 'implemented'"
-  const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
-  const PATH_SUFFIX_MATCH = /.*did not contain a required property of '([^']+)'$/
-
-  let initialPath = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
-                          .replace('/', '.');
-  let pathSuffix = message.replace(PATH_SUFFIX_MATCH, '$1');
-  let path = `${initialPath}.${pathSuffix}`;
-  let error = 'is required';
-
-  let propertyName = `${humanize(pathSuffix)} ${humanize(initialPath)}`;
-
-  return { path, error, propertyName };
-}
-
-function getInvalidPropertyError(message) {
-  // Example Error:
-  // "The property '#/alertNotifications/enabledNotifications' did not contain
-  // a minimum number of items 1"
-  const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
-
-  let path = message.replace(VALIDATION_PROPERTY_MATCH, '$1')
-                          .replace('/', '.');
-  let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
-                     .replace('did', 'does');
-  let property = path.split('.').reverse()[0];
-  let propertyName = humanize(property);
-
-  return { path, error, propertyName };
-}
+import AttestationValidationError from '../utils/attestation-validation-error';
 
 let Attestation = DS.Model.extend({
   handle: DS.attr('string'),
@@ -69,14 +25,7 @@ let Attestation = DS.Model.extend({
 
   validationErrors: Ember.computed('errors.[]', function() {
     let validationErrors = [];
-    this.get('errors').forEach((error) => {
-      if(MISSING_REQUIRED_PROPERTY_TEST.test(error.message)) {
-        validationErrors.push(getMissingPropertyError(error.message));
-      } else if(INVALID_PROPERTY_TEST.test(error.message)) {
-        validationErrors.push(getInvalidPropertyError(error.message));
-      }
-    });
-    return validationErrors;
+    return this.get('errors').map((e) => AttestationValidationError.create({ message: e.message }));
   })
 });
 

--- a/app/utils/attestation-validation-error.js
+++ b/app/utils/attestation-validation-error.js
@@ -1,0 +1,95 @@
+import Ember from 'ember';
+
+let { decamelize, capitalize } = Ember.String;
+let { match } = Ember.computed;
+
+const VALIDATION_PROPERTY_MATCH = /The property '#\/([^']+)'.+/;
+const MISSING_REQUIRED_PROPERTY_TEST = /did not contain a required property/;
+const MISSING_ITEM_PROPERTY_TEST = /did not contain a minimum number of items/;
+const ENUM_MISMATCH_PROPERTY_TEST = /did not match one of the following values/;
+
+function humanize(property) {
+  return capitalize(decamelize(property).replace(/_/ig, ' '));
+}
+
+function propertyNameFromPath(path) {
+  return humanize(path.split('.').reverse()[0]);
+}
+
+export default Ember.Object.extend({
+  init() {
+    this._super(...arguments);
+
+    let message = this.get('message');
+
+    if(message.match(MISSING_REQUIRED_PROPERTY_TEST)) {
+      this.initAsMissingRequiredPropertyError();
+    } else if(message.match(MISSING_ITEM_PROPERTY_TEST)) {
+      this.initAsMissingItemError();
+    } else if(message.match(ENUM_MISMATCH_PROPERTY_TEST)) {
+      this.initAsMissingEnumError();
+    } else {
+      this.initAsGenericPropertyError();
+    }
+  },
+
+  propertyPath: Ember.computed('message', function() {
+    return this.get('message').replace(VALIDATION_PROPERTY_MATCH, '$1')
+                              .replace(/\//ig, '.');
+  }),
+
+  initAsMissingRequiredPropertyError() {
+    // Example Error:
+    // "The property '#/separateOrganizationalUnits' did not contain a required
+    // property of 'implemented'"
+    const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+    const PATH_SUFFIX_MATCH = /.*did not contain a required property of '([^']+)'$/
+    let message = this.get('message');
+    let initialPath = this.get('propertyPath');
+    let pathSuffix = message.replace(PATH_SUFFIX_MATCH, '$1');
+    let path = `${initialPath}.${pathSuffix}`;
+    let error = 'is required';
+
+    let propertyName = `${humanize(pathSuffix)} ${humanize(initialPath)}`;
+
+    this.setProperties({ path, error, propertyName });
+  },
+
+  initAsMissingItemError() {
+    // Example Error:
+    // "The property '#/alertNotifications/enabledNotifications' did not contain
+    // a minimum number of items 1"
+    const VALIDATION_ERROR_MATCH = /The property '#\/.+' (.+)/;
+    let message = this.get('message');
+    let path = this.get('propertyPath');
+    let error = message.replace(VALIDATION_ERROR_MATCH, '$1')
+                       .replace('did', 'does');
+    let propertyName = propertyNameFromPath(path);
+
+    this.setProperties({ path, error, propertyName });
+  },
+
+  initAsMissingEnumError() {
+    // Example Error:
+    // The property '#/security_controls/application_unified_logging/technologies'
+    // value \"\" did not match one of the following values: ElasticSearch,
+    // Papertrail, Splunk, SumoLogic, Other
+    let message = this.get('message');
+    let path = this.get('propertyPath');
+
+    let REQUIRED_VALUES_MATCH = /^.+one of the following values: (.+)$/;
+    let requiredValues = message.replace(REQUIRED_VALUES_MATCH, '$1');
+    let error = `does not match one of the following values: ${requiredValues}`;
+    let propertyName = propertyNameFromPath(path);
+
+    this.setProperties({ path, error, propertyName });
+  },
+
+  initAsGenericPropertyError() {
+    let path = null;
+    let propertyName = null;
+    let error = this.get('message');
+
+    this.setProperties({ path, error, propertyName });
+  }
+});

--- a/tests/unit/utils/attestation-validation-error-test.js
+++ b/tests/unit/utils/attestation-validation-error-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import AttestationValidationError from '../../../utils/attestation-validation-error';
+
+module('Unit: AttestationValidationError');
+
+test('Missing required property error', function(assert) {
+  let message ="The property '#/separateOrganizationalUnits' did not contain a required property of 'implemented'";
+  let error = AttestationValidationError.create({ message });
+  let expected = { path: 'separateOrganizationalUnits.implemented',
+                   propertyName: 'Implemented Separate organizational units',
+                   error: 'is required' };
+
+  assert.deepEqual(error.getProperties('path', 'propertyName', 'error'), expected);
+});
+
+test('Missing array item property error', function(assert) {
+  let message = "The property '#/alertNotifications/enabledNotifications' did not contain a minimum number of items 1";
+  let error = AttestationValidationError.create({ message });
+  let expected = { path: 'alertNotifications.enabledNotifications',
+                   propertyName: 'Enabled notifications',
+                   error: 'does not contain a minimum number of items 1' };
+
+  assert.deepEqual(error.getProperties('path', 'propertyName', 'error'), expected);
+});
+
+test('Enum mismatch property error', function(assert) {
+  let message ="The property '#/security_controls/application_unified_logging/technologies' value \"\" did not match one of the following values: ElasticSearch, Papertrail, Splunk, SumoLogic, Other";
+  let error = AttestationValidationError.create({ message });
+  let expected = { path: 'security_controls.application_unified_logging.technologies',
+                   propertyName: 'Technologies',
+                   error: 'does not match one of the following values: ElasticSearch, Papertrail, Splunk, SumoLogic, Other' };
+
+  assert.deepEqual(error.getProperties('path', 'propertyName', 'error'), expected);
+});
+
+test('Generic property error', function(assert) {
+  let message ="An error occurred";
+  let error = AttestationValidationError.create({ message });
+  let expected = { path: null,
+                   propertyName: null,
+                   error: message };
+
+  assert.deepEqual(error.getProperties('path', 'propertyName', 'error'), expected);
+});


### PR DESCRIPTION
The errors presented by JSON schema are quite ugly and useless, so we have quite a bit of code to make these errors more usable.  In particular, we transform the error paths into something Ember can understand.  This PR ports our code to handle these errors into their own module with unit tests.  It also adds a new error case for when an item doesn't match a required enum value.
